### PR TITLE
Added a rich-based progress

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -16,6 +16,8 @@ import yaml
 import concurrent.futures
 import zipfile
 import shutil
+from rich.progress import track
+from core.logger import console
 
 class Engine:
     def __init__(self, settings: Settings):
@@ -340,11 +342,11 @@ class Engine:
         # via brace-counting, which is far more robust.
         markdown_match = re.search(r'```(?:json)?\s*([\s\S]*?)\s*```', response, re.DOTALL)
         if markdown_match:
-            cleaned_response = markdown_match.group(1).strip()
+             cleaned_response = markdown_match.group(1).strip()
         else:
-            # Fallback: strip leading ```json / ``` and trailing ``` line-by-line
-            cleaned_response = re.sub(r'^```[a-zA-Z]*\s*\n?', '', response.strip())
-            cleaned_response = re.sub(r'\n?\s*```\s*$', '', cleaned_response).strip()
+             # Fallback: strip leading ```json / ``` and trailing ``` line-by-line
+             cleaned_response = re.sub(r'^```[a-zA-Z]*\s*\n?', '', response.strip())
+             cleaned_response = re.sub(r'\n?\s*```\s*$', '', cleaned_response).strip()
 
 
         # Strategy 1: Extract JSON using Brace Counting (Most Robust)
@@ -686,10 +688,10 @@ class Engine:
                     if file.endswith(".smali"):
                         files_to_process.append(os.path.join(root, file))
 
-        for file_path in files_to_process:
+        for file_path in track(files_to_process, description="Summarizing code...", console=console):
             with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read()
-            
+
             # Simple chunking by class
             chunks = content.split(".class ")
             for chunk in chunks:
@@ -716,7 +718,7 @@ class Engine:
         risky_files = []
         identify_risk_prompt = self._load_identify_risk_prompt()
 
-        for file_path, summary in summaries.items():
+        for file_path, summary in track(list(summaries.items()), description="Identifying risky files...", console=console):
             context = {
                 "system_prompt": "",
                 "vuln_prompt": identify_risk_prompt,
@@ -1124,7 +1126,7 @@ class Engine:
             
             with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
                 future_to_file = {executor.submit(self.analyze_file, file_path, rules_to_run): file_path for file_path in target_files}
-                for future in concurrent.futures.as_completed(future_to_file):
+                for future in track(concurrent.futures.as_completed(future_to_file), total=len(future_to_file), description="Deep scanning files...", console=console):
                     file_path = future_to_file[future]
                     try:
                         results = future.result()

--- a/core/engine.py
+++ b/core/engine.py
@@ -718,7 +718,7 @@ class Engine:
         risky_files = []
         identify_risk_prompt = self._load_identify_risk_prompt()
 
-        for file_path, summary in track(list(summaries.items()), description="Identifying risky files...", console=console):
+        for file_path, summary in track(summaries.items(), total=len(summaries), description="Identifying risky files...", console=console):
             context = {
                 "system_prompt": "",
                 "vuln_prompt": identify_risk_prompt,

--- a/core/logger.py
+++ b/core/logger.py
@@ -1,13 +1,18 @@
-import sys
 from loguru import logger
+from rich.console import Console
+from rich.text import Text
+
+# Shared with rich.progress bars (see core/engine.py) so log lines print
+# cleanly above an active progress bar instead of corrupting its render.
+console = Console()
 
 def setup_logger(verbose: bool = False):
     level = "DEBUG" if verbose else "INFO"
     logger.remove()
     logger.add(
-        sys.stdout,
+        lambda msg: console.print(Text.from_ansi(msg.rstrip("\n"))),
         colorize=True,
-        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
+        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> - <level>{message}</level>",
         level=level,
     )
     return logger

--- a/core/logger.py
+++ b/core/logger.py
@@ -11,6 +11,7 @@ def setup_logger(verbose: bool = False):
     logger.remove()
     logger.add(
         lambda msg: console.print(Text.from_ansi(msg.rstrip("\n"))),
+        enqueue=True,
         colorize=True,
         format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> - <level>{message}</level>",
         level=level,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 pydantic
 langchain
 requests
+rich


### PR DESCRIPTION
Added a rich-based progress bar to the three longest-running loops in the scan pipeline (summarize_chunks(), identify_risky_chunks(), and the ThreadPoolExecutor deep-scan loop in run()), giving users visual feedback (percentage, ETA) instead of a silent wait during large APK scans. This required adding rich to requirements.txt and wiring the progress bar through core/engine.py. As a follow-up fix, core/logger.py was also updated to share a single rich.console.Console instance between the logger and the progress bars — the log format was trimmed (dropped module:function:line for readability) and a newline-handling bug was fixed so log lines no longer get jammed together or corrupt the progress bar's rendering when they print concurrently.