### PR TITLE
Version 1.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,25 @@ on:
   pull_request:
 
 jobs:
+  test:
+    name: Unit Tests (deterministic, no LLM)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run test suite
+        # Layer-1 golden tests: detection-pattern coverage, engine pure functions,
+        # and config invariants. No LLM / network required.
+        run: pytest -q
+
   build-and-verify:
     name: Build & Sanity Check
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache/
 nosetests.xml
 coverage.xml
 *.cover

--- a/DIAGRAM.md
+++ b/DIAGRAM.md
@@ -12,7 +12,7 @@
                        |
                        v
 +----------------------+--------------------------------+
-|  PHASE 2: SMART SCOPE PROTECTION (The Immune System)  |  <-- [v1.1.3]
+|  PHASE 2: SMART SCOPE PROTECTION (The Immune System)  |
 |                                                       |
 |  [ All Smali/Java Files ]                             |
 |          |                                            |
@@ -22,23 +22,25 @@
 |     2. Blocklist: Drop known libs (androidx, r0...)   |
 |          |                                            |
 |          v                                            |
-|  [ Relevant Files Only ] (Noise Reduced by ~70%)      |
+|  [ Relevant Files Only ] (Libraries Discarded)        |
 +----------------------+--------------------------------+
                        |
                        v
-+----------------------+--------------------------------+
 +----------------------+--------------------------------+
 |  PHASE 3: DISCOVERY & RISK ID (Hybrid Pass)           |
 |                                                       |
 |    [ Loop: Analyze Relevant Files ]                   |
 |                 |                                     |
 |                 v                                     |
-|    [ REGEX FILTER (Zero Cost) ]                       |  <-- [NEW v1.1.5]
+|    [ REGEX FILTER (Zero Cost) ]                       |
 |    (Match 'detection_pattern'?)                       |
 |       NO |             | YES                          |
 |          v             v                              |
-|       [ Skip ]      [ LLM VERIFICATION ]              |
-|                     (Context & Logic Check)           |
+|       [ Skip ]   [ CACHE CHECK ] --HIT--> [ Reuse ]   |
+|                        | MISS                         |
+|                        v                              |
+|                  [ LLM VERIFICATION ]                 |
+|                  (Context & Logic Check)              |
 |                                |                      |
 |                                v                      |
 |                     [ Validate Finding ]              |
@@ -50,7 +52,7 @@
                        |
                        v
 +----------------------+--------------------------------+
-|  PHASE 4: INTELLIGENT CHAINING (Pass 2)               |  <-- [v1.1.3]
+|  PHASE 4: INTELLIGENT CHAINING (Pass 2)               |
 |                                                       |
 |      [ Build Global Context ]                         |
 |   (Summarize all findings from Phase 3)               |

--- a/banner.txt
+++ b/banner.txt
@@ -2,7 +2,7 @@
 |    \ ___ ___|_|_| |___|  |  |  |  |     |___|  |  |_ _ ___| |_ ___ ___ 
 |  |  |  _| . | | . |___|  |__|  |__| | | |___|     | | |   |  _| -_|  _|
 |____/|_| |___|_|___|   |_____|_____|_|_|_|   |__|__|___|_|_|_| |___|_|  
-					       CLI Version 1.1.9
+					       CLI Version 1.2.0
 					      
 Droid-LLM-Hunter: A tool to scan for vulnerabilities in Android applications.                                                                                                                                          
 

--- a/config/prompts/vuln_rules/fragment_injection.yaml
+++ b/config/prompts/vuln_rules/fragment_injection.yaml
@@ -25,5 +25,5 @@ prompt: |
 keywords:
   - "PreferenceActivity"
   - "isValidFragment"
-detection_pattern: ".super Landroid/preference/PreferenceActivity;"
+detection_pattern: "(\\.super Landroid/preference/PreferenceActivity;|extends\\s+PreferenceActivity)"
 tags: ["fragment_injection", "rce", "preference_activity"]

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -6,6 +6,9 @@ analysis:
   generate_exploit: false # Generate PoC scripts for vulnerabilities
   scan_libraries: false # If true, includes 3rd party libraries in scan scope.
   use_cross_reference_context: true # Use cross reference context
+  max_workers: 2 # [#6] Parallel deep-scan threads (raise for fast providers like Groq/Gemini)
+  use_cache: true # [#4] Reuse identical LLM responses (resume after crash/rate-limit)
+  max_input_chars: 30000 # [#5] Truncate file content over this size before sending to LLM (0 = off)
 
 # Apktool Configuration
 apktool:
@@ -20,7 +23,7 @@ llm:
   provider: ollama # or "ollama" or "gemini" or "groq" or "openai" or "anthropic"
   anthropic_api_key: ANTHROPIC_API_KEY # Replace with your Anthropic API key
   anthropic_model: claude-sonnet-4-20250514 # default model for anthropic or "claude-sonnet-4-5-20250929"
-  api_key: GEMINI_API_KEY # Replace with your Gemini API key
+  gemini_api_key: GEMINI_API_KEY # Replace with your Gemini API key
   gemini_model: gemini-2.0-flash # default model for gemini or "gemini-2.5-flash"
   groq_api_key: GROQ_API_KEY # Replace with your Groq API key
   groq_model: llama-3.1-8b-instant # default model for groq or "llama-3.3-70b-versatile"
@@ -30,6 +33,7 @@ llm:
   openai_model: gpt-4-turbo # default model for openai or "gpt-4-turbo"
   openrouter_api_key: OPENROUTER_API_KEY # Replace with your OpenRouter API key
   openrouter_model: google/gemini-2.5-flash #  default model for openrouter or "google/gemini-2.5-pro"
+  max_tokens: 4096 # [#6] Max output tokens per LLM call (raise if JSON/exploit output gets cut off)
 
 # Analysis Rules
 # Enable or disable specific vulnerability checks

--- a/core/config_loader.py
+++ b/core/config_loader.py
@@ -4,18 +4,25 @@ from typing import Optional, Dict, List
 
 class LLMSettings(BaseModel):
     provider: str
+    # Ollama (uses `model` + `ollama_url`)
     model: str
-    api_key: Optional[str] = None
     ollama_url: Optional[str] = None
+    # Gemini
     gemini_model: Optional[str] = None
+    gemini_api_key: Optional[str] = None
+    # Groq
     groq_model: Optional[str] = None
     groq_api_key: Optional[str] = None
+    # OpenAI
     openai_model: Optional[str] = None
     openai_api_key: Optional[str] = None
+    # Anthropic
     anthropic_model: Optional[str] = None
     anthropic_api_key: Optional[str] = None
+    # OpenRouter
     openrouter_model: Optional[str] = None
     openrouter_api_key: Optional[str] = None
+    max_tokens: int = 4096  # [#6] Max output tokens per LLM call (avoid truncated JSON/exploit)
 
 class ApktoolSettings(BaseModel):
     path: Optional[str] = None
@@ -30,35 +37,39 @@ class AnalysisSettings(BaseModel):
     decompiler_mode: str = "apktool" # apktool, jadx, hybrid
     generate_exploit: bool = False
     scan_libraries: bool = False # [New V1.1.7]
+    max_workers: int = 2          # [#6] Parallel deep-scan threads
+    use_cache: bool = True        # [#4] Reuse identical LLM responses (resume-friendly)
+    max_input_chars: int = 30000  # [#5] Truncate oversized file content before sending to LLM
  # Default to True for backward compatibility
 
 
 class RulesSettings(BaseModel):
-    sql_injection: bool
-    webview_xss: bool
-    hardcoded_secrets: bool
-    webview_deeplink: bool
-    insecure_file_permissions: bool
-    intent_spoofing: bool
-    insecure_random_number_generation: bool
-    jetpack_compose_security: bool
+    # Fields are kept in alphabetical order — this is the order `dlh.py list-rules` prints.
     biometric_bypass: bool
-    graphql_injection: bool
-    exported_components: bool
     deeplink_hijack: bool
-    insecure_storage: bool
-    path_traversal: bool
-    insecure_webview: bool
-    universal_logic_flaw: bool 
-    pending_intent_hijacking: bool
-    fragment_injection: bool
-    zip_slip: bool
     deeplink_logic_bypass: bool
-    unsafe_reflection: bool
-    webview_file_access: bool
-    insecure_deserialization: bool
-    strandhogg: bool
+    exported_components: bool
+    fragment_injection: bool
+    graphql_injection: bool
+    hardcoded_secrets: bool
     hardcoded_secrets_xml: bool
+    insecure_deserialization: bool
+    insecure_file_permissions: bool
+    insecure_random_number_generation: bool
+    insecure_storage: bool
+    insecure_webview: bool
+    intent_spoofing: bool
+    jetpack_compose_security: bool
+    path_traversal: bool
+    pending_intent_hijacking: bool
+    sql_injection: bool
+    strandhogg: bool
+    universal_logic_flaw: bool
+    unsafe_reflection: bool
+    webview_deeplink: bool
+    webview_file_access: bool
+    webview_xss: bool
+    zip_slip: bool
 
 class Settings(BaseModel):
     llm: LLMSettings

--- a/core/engine.py
+++ b/core/engine.py
@@ -27,7 +27,8 @@ class Engine:
         self.masvs_mapping = self._load_masvs_mapping()
         
         self.apk_name = "target_app" # Default fallback
-        self.vulnerability_findings = []  
+        self.vulnerability_findings = []
+        self.analysis_errors = []  # [FIX #2] Files/rules that failed LLM analysis (NOT clean)
         
         # Load Call Graph Builder if enabled
 
@@ -52,26 +53,128 @@ class Engine:
         return result_dict
 
     def _setup_llm_client(self):
-        if self.settings.llm.provider == "ollama":
-            return OllamaClient(model=self.settings.llm.model, url=self.settings.llm.ollama_url)
-        elif self.settings.llm.provider == "gemini":
-            return GeminiClient(model=self.settings.llm.gemini_model, api_key=self.settings.llm.api_key)
-        elif self.settings.llm.provider == "groq":
-            return GroqClient(model=self.settings.llm.groq_model, api_key=self.settings.llm.groq_api_key)
-        elif self.settings.llm.provider == "openai":
-            return OpenAIClient(model=self.settings.llm.openai_model, api_key=self.settings.llm.openai_api_key)
-        elif self.settings.llm.provider == "anthropic":
-            return AnthropicClient(model=self.settings.llm.anthropic_model, api_key=self.settings.llm.anthropic_api_key)
-        elif self.settings.llm.provider == "openrouter":
-            return OpenRouterClient(model=self.settings.llm.openrouter_model, api_key=self.settings.llm.openrouter_api_key)
+        provider = self.settings.llm.provider
+        max_tokens = self.settings.llm.max_tokens  # [#6] Configurable output limit
+
+        if provider == "ollama":
+            model = self.settings.llm.model
+            raw_client = OllamaClient(model=model, url=self.settings.llm.ollama_url, max_tokens=max_tokens)
+        elif provider == "gemini":
+            model = self.settings.llm.gemini_model
+            raw_client = GeminiClient(model=model, api_key=self.settings.llm.gemini_api_key, max_tokens=max_tokens)
+        elif provider == "groq":
+            model = self.settings.llm.groq_model
+            raw_client = GroqClient(model=model, api_key=self.settings.llm.groq_api_key, max_tokens=max_tokens)
+        elif provider == "openai":
+            model = self.settings.llm.openai_model
+            raw_client = OpenAIClient(model=model, api_key=self.settings.llm.openai_api_key, max_tokens=max_tokens)
+        elif provider == "anthropic":
+            model = self.settings.llm.anthropic_model
+            raw_client = AnthropicClient(model=model, api_key=self.settings.llm.anthropic_api_key, max_tokens=max_tokens)
+        elif provider == "openrouter":
+            model = self.settings.llm.openrouter_model
+            raw_client = OpenRouterClient(model=model, api_key=self.settings.llm.openrouter_api_key, max_tokens=max_tokens)
         else:
-            raise ValueError(f"Unsupported LLM provider: {self.settings.llm.provider}")
+            raise ValueError(f"Unsupported LLM provider: {provider}")
+
+        # [#4] Wrap in a content-addressed cache (resume + dedup). Key includes the model,
+        # so mixing providers/models never collides.
+        from core.llm_cache import CachedLLMClient
+        cache_dir = "output/.dlh_cache"
+        if self.settings.analysis.use_cache:
+            log.info("Response cache: ENABLED 💾")
+        return CachedLLMClient(raw_client, cache_dir, model=model, enabled=self.settings.analysis.use_cache)
 
     def get_status(self, result: dict) -> str:
         """Determines status from the structured JSON result."""
         if result.get("is_vulnerable"):
             return "Vulnerable"
         return "Not Vulnerable"
+
+    def _rule_should_run(self, rule_name: str, prompt_data: dict, content: str) -> bool:
+        """
+        [FIX #1] Per-rule regex gating for the deep-scan phase.
+
+        In non-'llm_only' modes, skip a rule's LLM call when the rule declares one or
+        more detection patterns and NONE of them match the file. Rules without any
+        pattern (pure-logic rules like universal_logic_flaw) always run. Bad patterns
+        fail open (run the LLM) so a broken regex never silently drops a rule.
+        """
+        if self.settings.analysis.filter_mode == "llm_only":
+            return True
+
+        import re
+        rule_patterns = []
+        if prompt_data.get("detection_pattern"):
+            rule_patterns.append(prompt_data["detection_pattern"])
+        static_block = prompt_data.get("static_analysis") or {}
+        if static_block.get("patterns"):
+            rule_patterns.extend(static_block["patterns"])
+
+        if not rule_patterns:
+            return True  # No pattern -> logic rule, always run.
+
+        try:
+            return any(re.search(p, content, re.IGNORECASE | re.DOTALL) for p in rule_patterns)
+        except re.error as e:
+            log.warning(f"Invalid detection pattern for rule '{rule_name}' ({e}); running LLM anyway.")
+            return True
+
+    def _is_failed_response(self, raw_result: str) -> bool:
+        """[FIX #2] True when the LLM client soft-failed (empty response after retries)."""
+        return not raw_result or not raw_result.strip()
+
+    def _truncate_for_llm(self, text: str) -> str:
+        """
+        [#5] Guard against oversized file content blowing the context window / cost.
+
+        Keeps the head (imports, class decl, early logic) and the tail (which holds any
+        appended external dependency context), dropping the middle with an explicit marker
+        so the LLM knows content was omitted. Controlled by analysis.max_input_chars (0 or
+        negative disables truncation).
+        """
+        limit = self.settings.analysis.max_input_chars
+        if not limit or limit <= 0 or len(text) <= limit:
+            return text
+
+        head_len = int(limit * 0.7)
+        tail_len = limit - head_len
+        omitted = len(text) - limit
+        log.debug(f"Truncating LLM input: {len(text)} -> {limit} chars ({omitted} omitted).")
+        return (
+            text[:head_len]
+            + f"\n\n... [TRUNCATED {omitted} chars to fit context limit] ...\n\n"
+            + text[-tail_len:]
+        )
+
+    def _build_error_result(self, file_path: str, rule_name: str, vuln_name: str, reason: str = "empty") -> dict:
+        """
+        [FIX #2 / B] Report entry for a rule/file that could NOT be analyzed (not clean).
+
+        reason:
+          "empty"       -> LLM returned nothing after retries (soft-fail).
+          "unparseable" -> LLM returned non-empty output that was not valid JSON
+                           (common with local models that answer in prose instead of JSON).
+        """
+        self.analysis_errors.append({"file": file_path, "rule": rule_name, "reason": reason})
+        if reason == "unparseable":
+            error_msg = ("LLM returned unparseable output (not valid JSON — likely prose, "
+                         "common with small local models). This file/rule was NOT verified — "
+                         "treat as unanalyzed, not clean.")
+        else:
+            error_msg = ("LLM analysis failed (empty response after retries). "
+                         "This file/rule was NOT verified — treat as unanalyzed, not clean.")
+        return {
+            "file": file_path,
+            "vulnerability": vuln_name,
+            "status": "Error",
+            "result": {
+                "is_vulnerable": False,
+                "status_detail": "UNANALYZED",
+                "error": error_msg,
+                "description": "Analysis could not be completed for this rule.",
+            },
+        }
 
     def _find_manifest_path(self, start_path: str) -> str:
         """Traverses up the directory tree to find AndroidManifest.xml."""
@@ -210,7 +313,6 @@ class Engine:
                 prompt_template = f.read()
             
             prompt = prompt_template.replace("{vulnerability_description}", vuln_description)
-            prompt = prompt.replace("{file_path}", file_path)
             prompt = prompt.replace("{file_path}", file_path)
             prompt = prompt.replace("{manifest_context}", manifest_context) # Inject Manifest
             prompt = prompt.replace("{detected_secrets}", detected_secrets_str) # Inject Secrets
@@ -399,6 +501,7 @@ class Engine:
 
         log.warning(f"Failed to parse LLM response as JSON. Raw: {response[:100]}...")
         return {
+                "_parse_failed": True,  # [B] Signals unparseable (non-empty) output to callers.
                 "is_vulnerable": False,
                 "severity": "Info",
                 "confidence": "Low",
@@ -453,6 +556,8 @@ class Engine:
         
         # Combine snippets for the prompt
         full_code_context = code_snippet + external_context
+        # [#5] Cap oversized content before it reaches the LLM.
+        full_code_context = self._truncate_for_llm(full_code_context)
 
         # [V1.1.7 Library Hunter - Exclusive Mode]
         # Logic: If this is a 3rd party library file, we run ONLY the specialized audit prompt.
@@ -494,15 +599,30 @@ class Engine:
                  context = {
                     "system_prompt": system_prompt,
                     "vuln_prompt": prompt_data["prompt"],
-                    "file_path": file_path
+                    "file_path": file_path,
+                    "expect_json": True  # [A] Rule analysis requires JSON output
                  }
-                 
+
                  # Run Analysis
                  try:
                      raw_result = self.llm_client.analyze_code(full_code_context, context)
+
+                     # [FIX #2] A failed LLM call must not read as a clean library.
+                     if self._is_failed_response(raw_result):
+                         log.warning(f"LLM library scan failed for {os.path.basename(file_path)}; marking as Error (not clean).")
+                         results.append(self._build_error_result(file_path, "library_vulnerability", "Library Hunter"))
+                         return results
+
                      parsed_result = self._parse_llm_response(raw_result)
+
+                     # [B] Non-empty but unparseable (e.g. prose from a local model) -> Error, not clean.
+                     if parsed_result.get("_parse_failed"):
+                         log.warning(f"Unparseable LLM output for library scan of {os.path.basename(file_path)}; marking as Error.")
+                         results.append(self._build_error_result(file_path, "library_vulnerability", "Library Hunter", reason="unparseable"))
+                         return results
+
                      status = self.get_status(parsed_result)
-                 
+
                      if status == "Vulnerable":
                          parsed_result = self._enrich_result("library_vulnerability", parsed_result)
                          if self.settings.analysis.generate_exploit:
@@ -527,15 +647,19 @@ class Engine:
              # for granular library internals, or are covered by the general 'Library Audit' prompt.
              return results
 
-        for rule_name, enabled in self.settings.rules.dict().items():
+        for rule_name, enabled in self.settings.rules.model_dump().items():
             if enabled and rule_name not in ["webview_deeplink", "intent_spoofing", "exported_components", "deeplink_hijack"]:
                 if rules_to_run and rule_name not in rules_to_run:
                     continue
                 prompt_path = f"config/prompts/vuln_rules/{rule_name}.yaml"
                 with open(prompt_path, "r") as f:
                     prompt_data = yaml.safe_load(f)
-                
-                
+
+                # [FIX #1] Skip this rule's LLM call if its detection pattern doesn't match.
+                if not self._rule_should_run(rule_name, prompt_data, full_code_context):
+                    log.debug(f"Gated: rule '{rule_name}' skipped for {os.path.basename(file_path)} (no pattern match).")
+                    continue
+
                 # --- MASVS CONTEXT INJECTION (LITE RAG) ---
                 system_prompt = self._load_system_prompt()
                 
@@ -564,14 +688,29 @@ class Engine:
                 context = {
                     "system_prompt": system_prompt,
                     "vuln_prompt": vuln_prompt,
-                    "file_path": file_path
+                    "file_path": file_path,
+                    "expect_json": True  # [A] Rule analysis requires JSON output
                 }
-                
+
                 # Pass the ENRICHED context
                 raw_result = self.llm_client.analyze_code(full_code_context, context)
+
+                # [FIX #2] Distinguish a failed LLM call from a genuine "clean" verdict.
+                if self._is_failed_response(raw_result):
+                    log.warning(f"LLM analysis failed for rule '{rule_name}' on {os.path.basename(file_path)}; marking as Error (not clean).")
+                    results.append(self._build_error_result(file_path, rule_name, prompt_data["name"]))
+                    continue
+
                 parsed_result = self._parse_llm_response(raw_result)
+
+                # [B] Non-empty but unparseable (e.g. prose from a local model) -> Error, not clean.
+                if parsed_result.get("_parse_failed"):
+                    log.warning(f"Unparseable LLM output for rule '{rule_name}' on {os.path.basename(file_path)}; marking as Error.")
+                    results.append(self._build_error_result(file_path, rule_name, prompt_data["name"], reason="unparseable"))
+                    continue
+
                 status = self.get_status(parsed_result)
-                
+
                 # Enrich with MASVS
                 if status == "Vulnerable":
                     parsed_result = self._enrich_result(rule_name, parsed_result)
@@ -610,13 +749,28 @@ class Engine:
                 context = {
                     "system_prompt": self._load_system_prompt(),
                     "vuln_prompt": prompt_data["prompt"],
-                    "file_path": manifest_path
+                    "file_path": manifest_path,
+                    "expect_json": True  # [A] Rule analysis requires JSON output
                 }
 
                 raw_result = self.llm_client.analyze_code(code_snippet, context)
+
+                # [FIX #2] Failed manifest analysis is not a clean verdict.
+                if self._is_failed_response(raw_result):
+                    log.warning(f"LLM analysis failed for manifest rule '{rule_name}'; marking as Error (not clean).")
+                    results.append(self._build_error_result(manifest_path, rule_name, prompt_data["name"]))
+                    continue
+
                 parsed_result = self._parse_llm_response(raw_result)
+
+                # [B] Non-empty but unparseable output -> Error, not clean.
+                if parsed_result.get("_parse_failed"):
+                    log.warning(f"Unparseable LLM output for manifest rule '{rule_name}'; marking as Error.")
+                    results.append(self._build_error_result(manifest_path, rule_name, prompt_data["name"], reason="unparseable"))
+                    continue
+
                 status = self.get_status(parsed_result)
-                
+
                 # Enrich with MASVS
                 if status == "Vulnerable":
                     parsed_result = self._enrich_result(rule_name, parsed_result)
@@ -677,13 +831,26 @@ class Engine:
         context = {
             "system_prompt": self._load_system_prompt(),
             "vuln_prompt": prompt_data["prompt"],
-            "file_path": strings_path
+            "file_path": strings_path,
+            "expect_json": True  # [A] Rule analysis requires JSON output
         }
 
         raw_result = self.llm_client.analyze_code(code_snippet, context)
+
+        # [FIX #2] Failed strings.xml analysis is not a clean verdict.
+        if self._is_failed_response(raw_result):
+            log.warning(f"LLM analysis failed for '{rule_name}' on strings.xml; marking as Error (not clean).")
+            return [self._build_error_result(strings_path, rule_name, prompt_data["name"])]
+
         parsed_result = self._parse_llm_response(raw_result)
+
+        # [B] Non-empty but unparseable output -> Error, not clean.
+        if parsed_result.get("_parse_failed"):
+            log.warning(f"Unparseable LLM output for '{rule_name}' on strings.xml; marking as Error.")
+            return [self._build_error_result(strings_path, rule_name, prompt_data["name"], reason="unparseable")]
+
         status = self.get_status(parsed_result)
-        
+
         if status == "Vulnerable":
             # [V1.1.3] DEFERRED GENERATION
             if self.settings.analysis.generate_exploit:
@@ -720,23 +887,33 @@ class Engine:
             with open(file_path, "r", encoding="utf-8") as f:
                 content = f.read()
 
-            # Simple chunking by class
-            chunks = content.split(".class ")
-            for chunk in chunks:
-                if not chunk.strip():
-                    continue
-                
-                full_chunk = ".class " + chunk
-                
+            # Chunk by class only for Smali, where each class is its own ".class " block.
+            # Java/Kotlin sources (JADX/hybrid) don't use that token — splitting on it would
+            # either leave the whole file as one misleadingly-prefixed chunk or mis-slice at
+            # class literals (e.g. `Foo.class ==`), so treat the file as a single chunk.
+            if file_path.endswith(".smali"):
+                chunks = [".class " + c for c in content.split(".class ") if c.strip()]
+            else:
+                chunks = [content] if content.strip() else []
+
+            # [FIX #3] Accumulate every chunk's summary per file instead of overwriting.
+            # A multi-class Smali file has several ".class" chunks; keeping only the last
+            # one lost context used by risk identification and cross-reference injection.
+            file_summaries = []
+            for full_chunk in chunks:
                 context = {
                     "system_prompt": "",
                     "vuln_prompt": summarize_prompt,
                     "file_path": file_path
                 }
-                
-                summary = self.llm_client.analyze_code(full_chunk, context)
-                summaries[file_path] = summary
+
+                # [#5] Cap oversized chunks before summarization too.
+                summary = self.llm_client.analyze_code(self._truncate_for_llm(full_chunk), context)
+                if summary and summary.strip():
+                    file_summaries.append(summary.strip())
                 log.debug(f"Summary for {file_path}: {summary}")
+
+            summaries[file_path] = "\n".join(file_summaries)
 
         log.success("Code summarization complete.")
         return summaries
@@ -926,7 +1103,7 @@ class Engine:
 
         smali_rules_enabled = any(
             enabled and rule_name not in ["webview_deeplink", "intent_spoofing", "exported_components", "deeplink_hijack"]
-            for rule_name, enabled in self.settings.rules.dict().items()
+            for rule_name, enabled in self.settings.rules.model_dump().items()
         )
 
         self.summaries = {}
@@ -939,7 +1116,7 @@ class Engine:
             # --- DYNAMIC KEYWORD & REGEX GATHERING ---
             extra_keywords = []
             extra_regex = [] # [V1.2] Regex Support
-            for rule_name, enabled in self.settings.rules.dict().items():
+            for rule_name, enabled in self.settings.rules.model_dump().items():
                 if enabled and rule_name not in ["webview_deeplink", "intent_spoofing", "exported_components", "deeplink_hijack", "strandhogg"]:
                      try:
                         prompt_path = f"config/prompts/vuln_rules/{rule_name}.yaml"
@@ -1134,6 +1311,7 @@ class Engine:
 
         # Clear previous findings before scan
         self.vulnerability_findings = []
+        self.analysis_errors = []  # [FIX #2] Reset unanalyzed-file tracker
 
         # Analyze the manifest file
         all_results = self.analyze_manifest(manifest_path, rules_to_run)
@@ -1145,14 +1323,14 @@ class Engine:
                     all_results.extend(strings_results)
             except NameError:
                 pass # strings_results might not be defined if scope skipped
-            # Analyze the identified files
-            # Note: analyze_file handles reading the file content logic.
-            # Does it handle .java? Yes, strictly text read.
-            # But context injection? CallGraph only knows Smali paths. 
-            # If passing .java, context injection (get_dependencies) currently fails or returns nothing.
-            # We accept this limitation for now (Java analysis has better inherent context).
+            # Analyze the identified files (may be .smali or .java).
+            # Context injection works for both: the call graph is Smali-based, but
+            # get_dependencies()/path_to_class() normalize .java paths (sources/) to the
+            # same class names, so JADX/hybrid Java files still receive dependency context.
             
-            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            max_workers = max(1, self.settings.analysis.max_workers)  # [#6] Configurable parallelism
+            log.info(f"Deep scanning with {max_workers} worker(s)...")
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 future_to_file = {executor.submit(self.analyze_file, file_path, rules_to_run): file_path for file_path in target_files}
                 for future in track(concurrent.futures.as_completed(future_to_file), total=len(future_to_file), description="Deep scanning files...", console=console):
                     file_path = future_to_file[future]
@@ -1165,7 +1343,10 @@ class Engine:
         final_report = {
             "app_summary": app_summary,
             "attack_surface_map": attack_surface_map,
-            "results": all_results
+            "results": all_results,
+            # [FIX #2] Surface unanalyzed file/rule pairs so a failed scan can't be
+            # mistaken for a clean one.
+            "analysis_errors": self.analysis_errors,
         }
 
         # [V1.1.3] Generate Chained Exploits (Phase 2)
@@ -1177,6 +1358,20 @@ class Engine:
             import json
             json.dump(final_report, f, indent=2)
         log.success(f"Analysis complete. Results saved to {self.final_output_file}")
+
+        # [FIX #2] Warn loudly when some files/rules could not be analyzed.
+        if self.analysis_errors:
+            log.warning(
+                f"{len(self.analysis_errors)} file/rule check(s) could NOT be analyzed "
+                f"(LLM failures). These are marked status='Error' and must NOT be read as clean. "
+                f"See 'analysis_errors' in the report."
+            )
+
+        # [#4] Report cache effectiveness.
+        if hasattr(self.llm_client, "cache_stats"):
+            stats = self.llm_client.cache_stats()
+            if stats.get("enabled"):
+                log.info(f"Response cache: {stats['hits']} hit(s), {stats['misses']} miss(es).")
 
     def _load_system_prompt(self) -> str:
         with open("config/prompts/system_prompt.txt", "r") as f:

--- a/core/llm_cache.py
+++ b/core/llm_cache.py
@@ -1,0 +1,93 @@
+import os
+import hashlib
+from typing import Dict, Any
+from core import log
+
+
+class CachedLLMClient:
+    """
+    [#4] Content-addressed cache wrapper around any LLM client.
+
+    The cache key is a SHA-256 of (model + system_prompt + vuln_prompt + code_snippet),
+    so it is naturally correct: change the model, the rule prompt, or the analyzed code
+    and the key changes -> the call re-runs. Identical inputs hit the cache.
+
+    This gives two things at once:
+      - Resume: a scan that crashed or hit a rate limit re-uses every completed call
+        on the next run instead of paying for it again.
+      - Dedup: the same file summarized/analyzed twice costs one call.
+
+    Only NON-EMPTY responses are cached. A failed call (empty string after retries, per
+    the clients' soft-fail) is never stored, so a later resume retries it rather than
+    permanently caching a failure as if it were a real answer.
+
+    Unknown attribute access is delegated to the wrapped client, so this behaves like a
+    drop-in replacement for the real client everywhere in the engine.
+    """
+
+    def __init__(self, client, cache_dir: str, model: str, enabled: bool = True):
+        # Set via __dict__ to avoid triggering __getattr__ during init.
+        self.__dict__["_client"] = client
+        self.__dict__["enabled"] = enabled
+        self.__dict__["model"] = model or ""
+        self.__dict__["cache_dir"] = cache_dir
+        self.__dict__["hits"] = 0
+        self.__dict__["misses"] = 0
+        if enabled:
+            try:
+                os.makedirs(cache_dir, exist_ok=True)
+            except Exception as e:
+                log.warning(f"Could not create cache dir '{cache_dir}': {e}. Caching disabled.")
+                self.__dict__["enabled"] = False
+
+    def _key(self, code_snippet: str, context: Dict[str, Any]) -> str:
+        h = hashlib.sha256()
+        for part in (
+            self.model,
+            context.get("system_prompt", "") or "",
+            context.get("vuln_prompt", "") or "",
+            code_snippet or "",
+        ):
+            h.update(part.encode("utf-8", errors="replace"))
+            h.update(b"\x00")
+        return h.hexdigest()
+
+    def _path(self, key: str) -> str:
+        return os.path.join(self.cache_dir, f"{key}.txt")
+
+    def analyze_code(self, code_snippet: str, context: Dict[str, Any]) -> str:
+        if not self.enabled:
+            return self._client.analyze_code(code_snippet, context)
+
+        key = self._key(code_snippet, context)
+        path = self._path(key)
+
+        if os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    cached = f.read()
+                self.__dict__["hits"] += 1
+                log.debug(f"Cache HIT ({key[:12]}) for {context.get('file_path', 'N/A')}")
+                return cached
+            except Exception as e:
+                log.debug(f"Cache read failed for {key[:12]}: {e}")
+
+        result = self._client.analyze_code(code_snippet, context)
+        self.__dict__["misses"] += 1
+
+        # Only persist successful responses so failures are retried on resume.
+        if result and result.strip():
+            try:
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(result)
+            except Exception as e:
+                log.debug(f"Cache write failed for {key[:12]}: {e}")
+
+        return result
+
+    def cache_stats(self) -> dict:
+        return {"hits": self.hits, "misses": self.misses, "enabled": self.enabled}
+
+    def __getattr__(self, name):
+        # Only reached for attributes not found on this wrapper -> delegate to real client.
+        return getattr(self.__dict__["_client"], name)

--- a/dlh.py
+++ b/dlh.py
@@ -1,11 +1,48 @@
 # pyrefly: ignore [missing-import]
 import typer
+from typer import rich_utils as _rich_utils
+from rich.panel import Panel as _Panel
+from rich.table import Table as _Table
 from core.config_loader import load_settings
 from core import log
 from core.engine import Engine
 from core.logger import setup_logger
 
-app = typer.Typer()
+app = typer.Typer(
+    add_completion=False,            # hide --install-completion / --show-completion
+    rich_markup_mode="rich",
+)
+
+# --- Boxed "Examples" panel on the top-level `dlh.py --help` -------------------
+# Typer's `epilog` only renders as loose text, so to get a bordered panel that
+# matches the Commands/Options boxes we render one ourselves by wrapping Typer's
+# own rich help renderer. Gated to the root help (ctx.parent is None) so it does
+# not appear on `scan --help` / `config --help`.
+_HELP_EXAMPLES = [
+    ("python dlh.py scan app.apk", "Basic scan"),
+    ("python dlh.py scan app.apk --generate-exploit", "Scan + PoC"),
+    ("python dlh.py scan app.apk --scan-libraries", "Library Hunter"),
+    ('python dlh.py -r "sql_injection,webview_xss" scan app.apk', "Specific rules"),
+    ("python dlh.py --list-rules", "List all rules"),
+]
+
+_orig_rich_format_help = _rich_utils.rich_format_help
+
+
+def _rich_format_help_with_examples(*, obj, ctx, markup_mode):
+    _orig_rich_format_help(obj=obj, ctx=ctx, markup_mode=markup_mode)
+    if ctx.parent is None:  # top-level help only
+        console = _rich_utils._get_rich_console()
+        table = _Table(box=None, show_header=False, pad_edge=False, expand=False)
+        table.add_column(style="cyan", no_wrap=True)
+        table.add_column(style="dim")
+        for cmd, desc in _HELP_EXAMPLES:
+            table.add_row(cmd, desc)
+        console.print(_Panel(table, title="Examples", title_align="left", border_style="cyan"))
+        console.print("  Docs: https://github.com/roomkangali/droid-llm-hunter", style="dim")
+
+
+_rich_utils.rich_format_help = _rich_format_help_with_examples
 
 def list_rules_callback(value: bool):
     if value:
@@ -16,12 +53,12 @@ def list_rules_callback(value: bool):
         raise typer.Exit()
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context, 
-         verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging."),
-         output: str = typer.Option(None, "--output", "-o", help="Output file for the scan results."),
-         no_decompile: bool = typer.Option(False, "--no-decompile", help="Skip the decompilation step."),
-         rules: str = typer.Option(None, "--rules", "-r", help="Comma-separated list of rules to run."),
-         profile: str = typer.Option(None, "--profile", "-p", help="Configuration profile to use."),
+def main(ctx: typer.Context,
+         verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose logging.", rich_help_panel="Scan Options"),
+         output: str = typer.Option(None, "--output", "-o", help="Output file for the scan results.", rich_help_panel="Scan Options"),
+         no_decompile: bool = typer.Option(False, "--no-decompile", help="Skip the decompilation step.", rich_help_panel="Scan Options"),
+         rules: str = typer.Option(None, "--rules", "-r", help="Comma-separated list of rules to run.", rich_help_panel="Scan Options"),
+         profile: str = typer.Option(None, "--profile", "-p", help="Configuration profile to use.", rich_help_panel="Scan Options"),
          list_rules: bool = typer.Option(False, "--list-rules", help="List all available rules and exit.", callback=list_rules_callback, is_eager=True)):
     """
     Droid-LLM-Hunter: A tool to scan for vulnerabilities in Android applications.
@@ -36,6 +73,7 @@ def main(ctx: typer.Context,
              log.warning("banner.txt not found.")
         except Exception as e:
              log.debug(f"Could not load banner: {e}")
+        print("Run 'python dlh.py --help' to get started.\n")
 
     setup_logger(verbose)
     ctx.meta["output"] = output
@@ -43,11 +81,12 @@ def main(ctx: typer.Context,
     ctx.meta["rules"] = rules
     ctx.meta["profile"] = profile
 
-@app.command()
-def scan(ctx: typer.Context, 
+@app.command(no_args_is_help=True)
+def scan(ctx: typer.Context,
          apk_path: str = typer.Argument(..., help="Path to the APK file to analyze."),
          generate_exploit: bool = typer.Option(False, "--generate-exploit", help="Generate PoC scripts for detected vulnerabilities."),
-         scan_libraries: bool = typer.Option(False, "--scan-libraries", help="Include 3rd party libraries in scan scope (e.g. androidx, google, okhttp).")):
+         scan_libraries: bool = typer.Option(False, "--scan-libraries", help="Include 3rd party libraries in scan scope (e.g. androidx, google, okhttp)."),
+         no_cache: bool = typer.Option(False, "--no-cache", help="Disable the LLM response cache (force fresh calls, no resume).")):
     """
     Scan an APK file for vulnerabilities.
     """
@@ -65,7 +104,11 @@ def scan(ctx: typer.Context,
         if scan_libraries:
             settings.analysis.scan_libraries = True
             log.info("Library Hunter Mode: ENABLED 📚")
-            
+
+        if no_cache:
+            settings.analysis.use_cache = False
+            log.info("Response cache: DISABLED (--no-cache)")
+
         log.info("Configuration loaded successfully.")
         engine = Engine(settings)
         engine.run(apk_path, output, no_decompile, rules)
@@ -73,7 +116,7 @@ def scan(ctx: typer.Context,
         log.error(f"An error occurred during the scan: {e}")
         raise typer.Exit(code=1)
 
-config_app = typer.Typer(help="Manage the configuration of Droid-LLM-Hunter.")
+config_app = typer.Typer(help="Manage the configuration of Droid-LLM-Hunter.", no_args_is_help=True)
 app.add_typer(config_app, name="config")
 
 @config_app.command("provider")
@@ -84,16 +127,16 @@ def set_provider(provider: str = typer.Argument(None, help="The LLM provider to 
     import yaml
     try:
         with open("config/settings.yaml", "r") as f:
-            settings = yaml.safe_load(f)
+            settings = yaml.safe_load(f) or {}
     except FileNotFoundError:
-        settings = {"llm": {}}
-    
+        settings = {}
+
     if provider is None:
         current_provider = settings.get("llm", {}).get("provider")
         print(f"Current LLM provider: {current_provider}")
         return
 
-    settings["llm"]["provider"] = provider
+    settings.setdefault("llm", {})["provider"] = provider
     
     with open("config/settings.yaml", "w") as f:
         yaml.dump(settings, f)
@@ -108,9 +151,9 @@ def set_model(model: str = typer.Argument(None, help="The LLM model to use.")):
     import yaml
     try:
         with open("config/settings.yaml", "r") as f:
-            settings = yaml.safe_load(f)
+            settings = yaml.safe_load(f) or {}
     except FileNotFoundError:
-        settings = {"llm": {}}
+        settings = {}
 
     provider = settings.get("llm", {}).get("provider")
 
@@ -143,11 +186,11 @@ def set_model(model: str = typer.Argument(None, help="The LLM model to use.")):
         print(f"Unknown provider '{provider}'. Supported: {', '.join(provider_model_key.keys())}")
         raise typer.Exit()
 
-    settings["llm"][key] = model
-        
+    settings.setdefault("llm", {})[key] = model
+
     with open("config/settings.yaml", "w") as f:
         yaml.dump(settings, f)
-        
+
     print(f"LLM model for {provider} set to: {model}")
 
 @config_app.command("rules")
@@ -361,12 +404,12 @@ def config_wizard():
         }
     elif provider == "gemini":
         gemini_model = typer.prompt("Enter Gemini model name", default="gemini-2.5-flash")
-        api_key = typer.prompt("Enter Gemini API key")
+        gemini_api_key = typer.prompt("Enter Gemini API key")
         settings = {
             "llm": {
                 "provider": provider,
                 "gemini_model": gemini_model,
-                "api_key": api_key
+                "gemini_api_key": gemini_api_key
             }
         }
     elif provider == "groq":

--- a/document/ARCHITECTURE_EXPLANATION.md
+++ b/document/ARCHITECTURE_EXPLANATION.md
@@ -56,6 +56,33 @@ Some rules target **configuration files** (XML) rather than source code. These b
 
 ---
 
+## 💾 Cross-Cutting Layer: The Response Cache
+
+Wrapping **every** stage above is a content-addressed **response cache**. Before *any* request reaches the LLM — summarization, risk identification, deep-scan verification, app summary, or exploit generation — the engine computes a hash of `model + system prompt + rule prompt + code` and checks disk (`output/.dlh_cache/`):
+
+```text
+        [ Any LLM call ]
+              |
+              v
+     +------------------+     HIT     +--------------------------+
+     |   CACHE CHECK    |------------>|  Return stored response  |
+     |  (hash lookup)   |             |   (0 tokens, instant)    |
+     +------------------+             +--------------------------+
+              | MISS
+              v
+     +------------------+   success   +--------------------------+
+     |  Call real LLM   |------------>|  Write response to cache |
+     +------------------+             +--------------------------+
+              | (empty / failed response -> NOT cached, retried later)
+```
+
+*   **HIT:** the stored response is returned instantly, at zero token cost.
+*   **MISS:** the LLM is called, and only a **successful** response is written back. Failed (empty) responses are never cached, so a later run retries them.
+
+This turns an interrupted scan (crash, rate limit) into a **free resume** — re-running the same command replays completed work from cache and only spends tokens on what remains — and deduplicates identical chunks within a single run. Because the key includes the model and prompt, changing either recomputes automatically. Toggle via `analysis.use_cache` or `--no-cache`. See [Configuration](CONFIGURATION.md#performance--cost-controls).
+
+---
+
 ## 🛠️ Technical Implementation
 
 1.  **Engine (`code_filter.py` & `engine.py`):**

--- a/document/CONFIGURATION.md
+++ b/document/CONFIGURATION.md
@@ -114,6 +114,43 @@ jadx:
 
 ---
 
+## Performance & Cost Controls
+
+These live under `analysis:` and `llm:` in `config/settings.yaml` and control speed, token cost, and resumability.
+
+### Response Cache (`analysis.use_cache`) — default `true`
+
+Every **successful** LLM response is cached on disk under `output/.dlh_cache/`, keyed by a hash of `model + system prompt + rule prompt + code`.
+
+- **Resume:** if a scan crashes or exhausts your rate limit, just run the **same command again** — completed calls are reused for free, only the unfinished ones hit the LLM.
+- **Dedup:** identical content analyzed twice costs a single call.
+
+Failed (empty) responses are never cached, so they are retried on the next run. The cache is *content-addressed*: change the model, a rule prompt, or the APK and the affected entries recompute automatically — no manual clearing needed.
+
+```bash
+# Disable for one run (force fresh calls, no resume):
+python dlh.py scan target.apk --no-cache
+
+# Reset the cache entirely:
+rm -rf output/.dlh_cache
+```
+
+At the end of a scan the log reports effectiveness, e.g. `Response cache: 40 hit(s), 2 miss(es).`
+
+### Parallelism (`analysis.max_workers`) — default `2`
+
+Number of files deep-scanned in parallel. Raise it for fast providers (Groq, Gemini); keep it low if you hit rate limits.
+
+### Input Truncation (`analysis.max_input_chars`) — default `30000`
+
+Caps how much file content is sent to the LLM per call (keeps the head + tail, drops the middle with a `[TRUNCATED …]` marker). Prevents oversized files from blowing the context window or inflating cost. Set `0` to disable.
+
+### Output Tokens (`llm.max_tokens`) — default `4096`
+
+Maximum tokens the LLM may return per call. Raise it if long JSON findings or generated exploits get cut off (a truncated response causes JSON parse failures).
+
+---
+
 ## Quick Config via CLI
 
 ```bash

--- a/document/FEATURES.md
+++ b/document/FEATURES.md
@@ -45,6 +45,8 @@
 
 - **🤖 Multi-Provider Support:** Run locally with **Ollama** (free & private) or scale up with **Gemini**, **Groq**, **OpenAI**, **Anthropic**, and **OpenRouter**.
 
+- **💾 Response Cache & Resume:** Every successful LLM response is cached (content-addressed by model + prompt + code). A scan interrupted by a crash or rate limit **resumes for free** on re-run — only unfinished work calls the LLM. Configurable parallelism (`max_workers`), input truncation (`max_input_chars`), and output limit (`max_tokens`) round out the cost controls. [Read the Docs](CONFIGURATION.md#performance--cost-controls)
+
 ---
 
 ## 💥 Output & Exploitation

--- a/document/SCAN-WORKFLOW.md
+++ b/document/SCAN-WORKFLOW.md
@@ -17,6 +17,8 @@ Droid LLM Hunter uses a multi-stage process to analyze an APK:
 7.  **Chained Exploit Generation:** The engine generates exploits that leverage the Global Context to connect vulnerabilities across files.
 8.  **Enrichment & Reporting:** Vulnerabilities are mapped to **OWASP MASVS** standards, and a detailed JSON report is generated.
 
+> **💾 Response Cache (cross-cutting):** Every LLM call in the stages above — summarization, risk identification, deep-scan verification, app summary, and exploit generation — passes through a content-addressed cache first. A HIT returns the stored answer for free; a MISS calls the LLM and stores the successful result. This makes an interrupted scan resume for free on re-run. See [Configuration](CONFIGURATION.md#response-cache-analysisuse_cache).
+
 ---
 
 ## Pipeline Diagram
@@ -57,8 +59,11 @@ Droid LLM Hunter uses a multi-stage process to analyze an APK:
 |    (Match 'detection_pattern'?)                       |
 |       NO |             | YES                          |
 |          v             v                              |
-|       [ Skip ]      [ LLM VERIFICATION ]              |
-|                     (Context & Logic Check)           |
+|       [ Skip ]   [ CACHE CHECK ] --HIT--> [ Reuse ]   |
+|                        | MISS                         |
+|                        v                              |
+|                  [ LLM VERIFICATION ]                 |
+|                  (Context & Logic Check)              |
 |                                |                      |
 |                                v                      |
 |                     [ Validate Finding ]              |

--- a/document/USAGE.md
+++ b/document/USAGE.md
@@ -24,10 +24,27 @@ python dlh.py scan [APK file]
   python dlh.py scan target.apk --generate-exploit
   ```
 
+- **Library Hunter Mode — scan 3rd-party libraries (supply-chain audit):**
+  ```bash
+  python dlh.py scan target.apk --scan-libraries
+  ```
+  > Bypasses Smart Scope Protection to hunt backdoors/droppers (e.g. `DexClassLoader`) inside SDKs, using strict regex to save tokens.
+
+- **Combine flags (full offensive run):**
+  ```bash
+  python dlh.py scan target.apk --generate-exploit --scan-libraries
+  ```
+
 - **Skip the decompilation step:**
   ```bash
   python dlh.py --no-decompile scan target.apk
   ```
+
+- **Disable the LLM response cache (force fresh calls, no resume):**
+  ```bash
+  python dlh.py scan target.apk --no-cache
+  ```
+  > By default the cache is ON: a scan interrupted by a crash or rate limit resumes for free when you re-run the same command. See [Response Cache](CONFIGURATION.md#response-cache-analysisuse_cache).
 
 - **Run only specific rules:**
   ```bash
@@ -53,6 +70,11 @@ python dlh.py scan [APK file]
 
 ## Flags
 
+> **Ordering matters:** global flags go **before** the `scan` command; scan options go **after** `scan <apk>`.
+> Example: `python dlh.py -v --rules "sql_injection" scan target.apk --generate-exploit`
+
+### Global Flags (before the command)
+
 ```
 +--------------------+------+----------------------------------------------------+
 | Flag               | Short| Description                                        |
@@ -66,31 +88,57 @@ python dlh.py scan [APK file]
 +--------------------+------+----------------------------------------------------+
 ```
 
+### Scan Options (after `scan <apk>`)
+
+```
++---------------------+----------------------------------------------------------+
+| Option              | Description                                               |
++---------------------+----------------------------------------------------------+
+| --generate-exploit  | Generate PoC scripts for confirmed vulnerabilities.      |
+| --scan-libraries    | Library Hunter Mode: include 3rd-party libraries in the  |
+|                     | scan scope (supply-chain / backdoor audit).              |
+| --no-cache          | Disable the LLM response cache (force fresh calls, no    |
+|                     | resume) for this run.                                    |
++---------------------+----------------------------------------------------------+
+```
+
 ---
 
 ## Commands
 
+> **Tip:** `provider`, `model`, `filter-mode`, and `decompiler-mode` **print the current value** when called with no argument (e.g. `config filter-mode`). `attack-surface` and `context-injection` print status when called with no `--enable/--disable`.
+
 ```
-+------------------------------------+---------------------------------------------------------------+
-| Command                            | Description                                                   |
-+------------------------------------+---------------------------------------------------------------+
-| scan                               | Scan an APK file for vulnerabilities.                         |
-| scan [APK] --generate-exploit      | Generate PoC scripts for confirmed vulnerabilities.           |
-| config wizard                      | Run the interactive configuration wizard.                     |
-| config provider <provider>         | Set the LLM provider.                                         |
-| config model <model>               | Set the LLM model.                                            |
-| config rules --enable <rules>      | Enable rules.                                                 |
-| config rules --disable <rules>     | Disable rules.                                                |
-| config validate                    | Validate the configuration file.                              |
-| config show                        | Show the current configuration.                               |
-| config profile create <name>       | Create a new profile.                                         |
-| config profile list                | List all available profiles.                                  |
-| config profile switch <name>       | Switch to a different profile.                                |
-| config profile delete <name>       | Delete a profile.                                             |
-| config attack-surface --enable     | Enable attack surface map generation.                         |
-| config context-injection --enable  | Enable Cross-Reference Context Injection.                     |
-| config filter-mode                 | Set or show the filter mode.                                  |
-| config decompiler-mode             | Set or show decompiler mode (apktool, jadx, hybrid).          |
-| list-rules                         | List all available rules.                                     |
-+------------------------------------+---------------------------------------------------------------+
++---------------------------------------+------------------------------------------------------------+
+| Command                               | Description                                                |
++---------------------------------------+------------------------------------------------------------+
+| scan <apk>                            | Scan an APK file for vulnerabilities.                      |
+| scan <apk> --generate-exploit         | Generate PoC scripts for confirmed vulnerabilities.        |
+| scan <apk> --scan-libraries           | Library Hunter Mode (scan 3rd-party libraries).            |
+| scan <apk> --no-cache                 | Disable the LLM response cache for this run.               |
+| list-rules                            | List all available rules.                                  |
+|                                       |                                                            |
+| config wizard                         | Run the interactive configuration wizard.                  |
+| config show                           | Show the current (merged) configuration.                   |
+| config validate                       | Validate the configuration file.                           |
+| config provider [provider]            | Set — or show, if omitted — the LLM provider.              |
+| config model [model]                  | Set — or show, if omitted — the LLM model.                 |
+| config rules --enable <rules>         | Enable the given comma-separated rules.                    |
+| config rules --disable <rules>        | Disable the given comma-separated rules.                   |
+| config rules                          | List currently enabled rules.                              |
+| config filter-mode [mode]             | Set/show filter mode (static_only, llm_only, hybrid).      |
+| config decompiler-mode [mode]         | Set/show decompiler mode (apktool, jadx, hybrid).          |
+| config attack-surface --enable        | Enable attack surface map generation.                      |
+| config attack-surface --disable       | Disable attack surface map generation.                     |
+| config context-injection --enable     | Enable Cross-Reference Context Injection (Call Graph).     |
+| config context-injection --disable    | Disable Cross-Reference Context Injection.                 |
+|                                       |                                                            |
+| config profile                        | List available profiles.                                   |
+| config profile create <name>          | Create a new profile (runs the wizard).                    |
+| config profile list                   | List all available profiles.                               |
+| config profile switch <name>          | Switch the active config to a profile.                     |
+| config profile delete <name>          | Delete a profile.                                          |
++---------------------------------------+------------------------------------------------------------+
 ```
+
+> **Note:** Performance/cost knobs — `max_workers`, `max_input_chars` (`analysis:`), and `max_tokens` (`llm:`) — are set in `config/settings.yaml`, not via CLI. See [Configuration → Performance & Cost Controls](CONFIGURATION.md#performance--cost-controls).

--- a/modules/decompiler/jadx_handler.py
+++ b/modules/decompiler/jadx_handler.py
@@ -61,8 +61,13 @@ class JadxHandler:
                 log.success(f"JADX decompilation successful: {output_abspath}")
                 return True
             elif has_sources:
-                 log.warning(f"JADX finished with errors (exit code {result.returncode}), but source code was generated. Proceeding...")
+                 # A non-zero exit with sources present is JADX's normal partial-decompile
+                 # outcome: some classes fail on almost every real APK (obfuscation, unusual
+                 # bytecode), JADX skips them and still emits the rest. This is the success
+                 # path, not a warning — keep it calm and push details to DEBUG (-v).
+                 log.info(f"JADX decompilation complete (exit code {result.returncode}; some classes skipped — normal).")
                  log.debug(f"JADX STDOUT: {result.stdout}")
+                 log.debug(f"JADX STDERR: {result.stderr}")
                  return True
             else:
                  log.error(f"JADX failed with exit code {result.returncode} and no sources found.")

--- a/modules/llm_client/anthropic.py
+++ b/modules/llm_client/anthropic.py
@@ -6,9 +6,10 @@ from typing import Dict, Any
 import time
 
 class AnthropicClient(BaseLLMClient):
-    def __init__(self, model: str, api_key: str):
+    def __init__(self, model: str, api_key: str, max_tokens: int = 4096):
         self.model = model
         self.api_key = api_key
+        self.max_tokens = max_tokens
         self.url = "https://api.anthropic.com/v1/messages"
 
     def analyze_code(self, code_snippet: str, context: Dict[str, Any]) -> str:
@@ -23,7 +24,7 @@ class AnthropicClient(BaseLLMClient):
         
         data = {
             "model": self.model,
-            "max_tokens": 4096,
+            "max_tokens": self.max_tokens,
             "messages": [
                 {
                     "role": "user",

--- a/modules/llm_client/gemini.py
+++ b/modules/llm_client/gemini.py
@@ -5,9 +5,10 @@ import requests
 import json
 
 class GeminiClient(BaseLLMClient):
-    def __init__(self, model: str, api_key: str):
+    def __init__(self, model: str, api_key: str, max_tokens: int = 4096):
         self.model = model
         self.api_key = api_key
+        self.max_tokens = max_tokens
         self.url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model}:generateContent"
 
     def analyze_code(self, code_snippet: str, context: Dict[str, Any]) -> str:
@@ -28,7 +29,10 @@ class GeminiClient(BaseLLMClient):
                         }
                     ]
                 }
-            ]
+            ],
+            "generationConfig": {
+                "maxOutputTokens": self.max_tokens
+            }
         }
 
         max_retries = 5

--- a/modules/llm_client/groq.py
+++ b/modules/llm_client/groq.py
@@ -5,9 +5,10 @@ from core import log
 from typing import Dict, Any
 
 class GroqClient(BaseLLMClient):
-    def __init__(self, model: str, api_key: str):
+    def __init__(self, model: str, api_key: str, max_tokens: int = 4096):
         self.model = model
         self.api_key = api_key
+        self.max_tokens = max_tokens
         self.url = "https://api.groq.com/openai/v1/chat/completions"
 
     def analyze_code(self, code_snippet: str, context: Dict[str, Any]) -> str:
@@ -21,6 +22,7 @@ class GroqClient(BaseLLMClient):
         
         data = {
             "model": self.model,
+            "max_tokens": self.max_tokens,
             "messages": [
                 {
                     "role": "user",

--- a/modules/llm_client/ollama.py
+++ b/modules/llm_client/ollama.py
@@ -5,8 +5,9 @@ from core import log
 from typing import Dict, Any
 
 class OllamaClient(BaseLLMClient):
-    def __init__(self, model: str, url: str):
+    def __init__(self, model: str, url: str, max_tokens: int = 4096):
         self.model = model
+        self.max_tokens = max_tokens
         self.url = f"{url}/api/generate"
 
     def analyze_code(self, code_snippet: str, context: Dict[str, Any]) -> str:
@@ -18,9 +19,23 @@ class OllamaClient(BaseLLMClient):
 
         for attempt in range(max_retries):
             try:
+                payload = {
+                    "model": self.model,
+                    "prompt": prompt,
+                    "stream": False,
+                    "options": {"num_predict": self.max_tokens},
+                }
+                # [A] Force valid JSON output for rule-analysis calls. Ollama's native
+                # format="json" constrains the model to emit JSON — this is what small
+                # local models (deepseek-coder, etc.) need since they otherwise answer in
+                # prose and break parsing. NOT set for summarize / risk-ID calls, which
+                # legitimately return free text.
+                if context.get("expect_json"):
+                    payload["format"] = "json"
+
                 response = requests.post(
                     self.url,
-                    json={"model": self.model, "prompt": prompt, "stream": False},
+                    json=payload,
                     timeout=600, # 10 minutes timeout
                 )
                 response.raise_for_status()

--- a/modules/llm_client/openai.py
+++ b/modules/llm_client/openai.py
@@ -5,9 +5,10 @@ from core import log
 from typing import Dict, Any
 
 class OpenAIClient(BaseLLMClient):
-    def __init__(self, model: str, api_key: str):
+    def __init__(self, model: str, api_key: str, max_tokens: int = 4096):
         self.model = model
         self.api_key = api_key
+        self.max_tokens = max_tokens
         self.url = "https://api.openai.com/v1/chat/completions"
 
     def analyze_code(self, code_snippet: str, context: Dict[str, Any]) -> str:
@@ -21,6 +22,7 @@ class OpenAIClient(BaseLLMClient):
         
         data = {
             "model": self.model,
+            "max_tokens": self.max_tokens,
             "messages": [
                 {
                     "role": "user",

--- a/modules/llm_client/openrouter.py
+++ b/modules/llm_client/openrouter.py
@@ -5,9 +5,10 @@ from core import log
 from typing import Dict, Any
 
 class OpenRouterClient(BaseLLMClient):
-    def __init__(self, model: str, api_key: str):
+    def __init__(self, model: str, api_key: str, max_tokens: int = 4096):
         self.model = model
         self.api_key = api_key
+        self.max_tokens = max_tokens
         self.url = "https://openrouter.ai/api/v1/chat/completions"
 
     def analyze_code(self, code_snippet: str, context: Dict[str, Any]) -> str:
@@ -25,6 +26,7 @@ class OpenRouterClient(BaseLLMClient):
         
         data = {
             "model": self.model,
+            "max_tokens": self.max_tokens,
             "messages": [
                 {
                     "role": "user",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+addopts = -q

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Development / test dependencies (not needed to run the scanner).
+#   pip install -r requirements-dev.txt
+#   pytest            # runs the deterministic (no-LLM) test suite
+-r requirements.txt
+pytest==9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-typer
-loguru
-pyyaml
-pydantic
-langchain
-requests
-rich
+# Droid-LLM-Hunter dependencies — pinned for reproducible builds (v1.2.0).
+# Versions reflect the tested environment. Loosen to ~=X.Y.Z if you want
+# automatic patch updates, or bump deliberately and re-test.
+typer==0.27.0
+loguru==0.7.3
+PyYAML==6.0.3
+pydantic==2.13.4
+requests==2.34.2
+rich==15.0.0

--- a/scripts/ci/configurator.py
+++ b/scripts/ci/configurator.py
@@ -92,7 +92,7 @@ def apply_llm_settings(settings: Dict[str, Any]) -> None:
 
         # API Key Configuration Mapping
         api_key_map = {
-            "gemini": "api_key",
+            "gemini": "gemini_api_key",
             "groq": "groq_api_key",
             "openai": "openai_api_key",
             "anthropic": "anthropic_api_key",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+import pytest
+
+# Repo root = parent of this tests/ directory.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+@pytest.fixture(autouse=True)
+def _chdir_repo_root(monkeypatch):
+    """The tool reads config/prompts via repo-relative paths, so run tests from the repo root."""
+    monkeypatch.chdir(REPO_ROOT)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,36 @@
+"""
+Golden test — Layer 1 (deterministic, no LLM).
+
+Locks in config-schema invariants: the shipped settings validate, rules stay A-Z
+(list-rules order), the rule count is stable, and the Gemini key field is consistent
+with the other providers (v1.2.0 #16 rename).
+"""
+from core.config_loader import load_settings, RulesSettings, LLMSettings
+
+
+def test_shipped_settings_are_valid():
+    s = load_settings()
+    assert s.llm.provider
+    assert s.analysis is not None
+    assert s.rules is not None
+
+
+def test_rules_are_alphabetical():
+    fields = list(RulesSettings.model_fields)
+    assert fields == sorted(fields), "RulesSettings must stay A-Z (drives list-rules order)"
+
+
+def test_rule_count_stable():
+    assert len(RulesSettings.model_fields) == 25
+
+
+def test_gemini_api_key_field_is_consistent():
+    # v1.2.0 #16: Gemini used the generic `api_key`; renamed to `gemini_api_key`.
+    assert "gemini_api_key" in LLMSettings.model_fields
+    assert "api_key" not in LLMSettings.model_fields
+
+
+def test_new_v120_settings_exist():
+    for field in ("max_workers", "use_cache", "max_input_chars"):
+        assert field in __import__("core.config_loader", fromlist=["AnalysisSettings"]).AnalysisSettings.model_fields
+    assert "max_tokens" in LLMSettings.model_fields

--- a/tests/test_detection_patterns.py
+++ b/tests/test_detection_patterns.py
@@ -1,0 +1,102 @@
+"""
+Golden test — Layer 1 (deterministic, no LLM).
+
+Validates that every rule's `detection_pattern` actually matches representative code
+in the DEFAULT `hybrid` (JADX / Java) mode. This is the layer that catches "dead rule"
+bugs where a Smali-only pattern never matches Java source (see the fragment_injection
+regression below). It mirrors CodeFilter, which compiles patterns with no extra flags.
+"""
+import glob
+import os
+import re
+
+import pytest
+import yaml
+
+RULES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "config", "prompts", "vuln_rules",
+)
+
+
+def _load(name):
+    with open(os.path.join(RULES_DIR, name + ".yaml")) as f:
+        return yaml.safe_load(f)
+
+
+def _all_rules():
+    return sorted(os.path.basename(p)[:-5] for p in glob.glob(os.path.join(RULES_DIR, "*.yaml")))
+
+
+# Representative snippets each rule's detection_pattern MUST match.
+# Java snippets reflect the default hybrid (JADX) mode; manifest rules use XML.
+POSITIVE = {
+    "biometric_bypass": "BiometricPrompt p = new BiometricPrompt(activity, exec, cb);",
+    "deeplink_hijack": '<data android:scheme="myapp" android:host="open"/>',
+    "deeplink_logic_bypass": 'String t = uri.getQueryParameter("token");',
+    "exported_components": '<activity android:name=".A" android:exported="true"/>',
+    "fragment_injection": "public class SettingsActivity extends PreferenceActivity {",
+    "graphql_injection": 'String query = "query { user(id:1){name} }";',
+    "hardcoded_secrets": 'String password = "hunter2";',
+    "insecure_deserialization": "ObjectInputStream ois = new ObjectInputStream(is); ois.readObject();",
+    "insecure_file_permissions": "openFileOutput(name, MODE_WORLD_READABLE);",
+    "insecure_random_number_generation": "Random r = new Random();",
+    "insecure_storage": 'getSharedPreferences("p", MODE_PRIVATE);',
+    "insecure_webview": 'webView.addJavascriptInterface(new Bridge(), "app");',
+    "intent_spoofing": '<receiver android:name=".R" android:exported="true"/>',
+    "jetpack_compose_security": "@Composable fun LoginScreen() {}",
+    "library_vulnerability": "DexClassLoader cl = new DexClassLoader(path, opt, null, parent);",
+    "path_traversal": "public ParcelFileDescriptor openFile(Uri uri, String mode) {",
+    "pending_intent_hijacking": "PendingIntent.getActivity(ctx, 0, i, PendingIntent.FLAG_MUTABLE);",
+    "sql_injection": 'db.rawQuery("SELECT * FROM u WHERE n=" + name, null);',
+    "unsafe_reflection": 'Class.forName(intent.getStringExtra("cls"));',
+    "universal_logic_flaw": "public boolean shouldOverrideUrlLoading(WebView v, String url) {",
+    "webview_deeplink": '<action android:name="android.intent.action.VIEW"/>',
+    "webview_file_access": "settings.setAllowFileAccess(true);",
+    "webview_xss": "settings.setJavaScriptEnabled(true);",
+    "zip_slip": "for (ZipEntry e : zip.entries()) { new File(dir, e.getName()); }",
+}
+
+# Rules that intentionally have NO detection_pattern (keyword-only / manifest heuristic).
+NO_PATTERN = {"strandhogg", "hardcoded_secrets_xml"}
+
+
+def test_every_rule_has_golden_coverage():
+    """If a new rule is added, force adding a snippet here (or listing it in NO_PATTERN)."""
+    for rule in _all_rules():
+        assert rule in POSITIVE or rule in NO_PATTERN, f"Rule '{rule}' has no golden coverage"
+
+
+@pytest.mark.parametrize("rule", sorted(POSITIVE))
+def test_detection_pattern_matches_sample(rule):
+    data = _load(rule)
+    pat = data.get("detection_pattern")
+    assert pat, f"Rule '{rule}' is expected to have a detection_pattern"
+    rx = re.compile(pat)  # mirrors CodeFilter (no external flags)
+    assert rx.search(POSITIVE[rule]), (
+        f"detection_pattern for '{rule}' does not match its default-mode sample: {POSITIVE[rule]!r}"
+    )
+
+
+def test_all_detection_patterns_compile():
+    for rule in _all_rules():
+        pat = _load(rule).get("detection_pattern")
+        if pat:
+            re.compile(pat)  # raises re.error if invalid
+
+
+def test_fragment_injection_matches_both_java_and_smali():
+    """Regression for the v1.2.0 [B] fix: this rule was Smali-only and dead in hybrid mode."""
+    rx = re.compile(_load("fragment_injection")["detection_pattern"])
+    assert rx.search("class X extends PreferenceActivity {"), "must match JADX/Java (default mode)"
+    assert rx.search(".super Landroid/preference/PreferenceActivity;"), "must still match apktool/Smali"
+
+
+@pytest.mark.parametrize("rule,benign", [
+    ("fragment_injection", "public class X extends Activity {"),
+    ("sql_injection", "int total = a + b;"),
+    ("insecure_random_number_generation", "int x = getRandomFromSecureSource();"),
+])
+def test_negative_cases_do_not_match(rule, benign):
+    rx = re.compile(_load(rule)["detection_pattern"])
+    assert not rx.search(benign), f"'{rule}' pattern should NOT match benign code: {benign!r}"

--- a/tests/test_pure_functions.py
+++ b/tests/test_pure_functions.py
@@ -1,0 +1,134 @@
+"""
+Golden test — Layer 1 (deterministic, no LLM).
+
+Locks in the v1.2.0 engine fixes so future refactors can't silently regress them:
+per-rule gating (#1), input truncation (#5), failure/parse handling (#2 / Ollama-JSON),
+the response cache (#4), and cross-language call-graph mapping.
+"""
+import types
+
+from core.engine import Engine
+from core.llm_cache import CachedLLMClient
+from core.call_graph import CallGraphBuilder
+
+
+def _engine():
+    # Bypass __init__ (which builds a real LLM client); we only test pure methods.
+    return object.__new__(Engine)
+
+
+# ---- #1 per-rule regex gating -------------------------------------------------
+def test_rule_should_run_gating():
+    e = _engine()
+    e.settings = types.SimpleNamespace(analysis=types.SimpleNamespace(filter_mode="hybrid"))
+    pd = {"detection_pattern": r"execSQL\s*\("}
+    assert e._rule_should_run("sql", pd, "db.execSQL(x)") is True
+    assert e._rule_should_run("sql", pd, "int x = 1;") is False
+    assert e._rule_should_run("logic", {"prompt": "..."}, "anything") is True  # no pattern -> run
+    # llm_only bypasses gating entirely
+    e.settings.analysis.filter_mode = "llm_only"
+    assert e._rule_should_run("sql", pd, "int x = 1;") is True
+    # bad regex fails open (runs the LLM rather than silently dropping the rule)
+    e.settings.analysis.filter_mode = "hybrid"
+    assert e._rule_should_run("x", {"detection_pattern": r"([unclosed"}, "y") is True
+
+
+# ---- #5 input truncation ------------------------------------------------------
+def test_truncate_for_llm():
+    e = _engine()
+    e.settings = types.SimpleNamespace(analysis=types.SimpleNamespace(max_input_chars=100))
+    big = "H" * 80 + "M" * 100 + "T" * 80
+    out = e._truncate_for_llm(big)
+    assert len(out) < len(big) and "TRUNCATED" in out
+    assert out.startswith("H") and out.rstrip().endswith("T")
+    assert e._truncate_for_llm("short") == "short"
+    e.settings.analysis.max_input_chars = 0  # disabled
+    assert e._truncate_for_llm(big) == big
+
+
+# ---- #2 / Ollama-JSON: failure & parse handling -------------------------------
+def test_is_failed_response():
+    e = _engine()
+    assert e._is_failed_response("") is True
+    assert e._is_failed_response("   ") is True
+    assert e._is_failed_response(None) is True
+    assert e._is_failed_response('{"x": 1}') is False
+
+
+def test_parse_prose_is_flagged_not_clean():
+    e = _engine()
+    parsed = e._parse_llm_response("Yes, there is a SQL injection vulnerability here.")
+    assert parsed.get("_parse_failed") is True
+    assert parsed.get("is_vulnerable") is False
+
+
+def test_parse_valid_json():
+    e = _engine()
+    ok = e._parse_llm_response('{"is_vulnerable": true, "severity": "High"}')
+    assert ok["is_vulnerable"] is True
+    assert "_parse_failed" not in ok
+
+
+def test_parse_fenced_json_with_nested_braces_in_evidence():
+    e = _engine()
+    raw = '```json\n{"is_vulnerable": true, "evidence": "if (a) {b();}"}\n```'
+    parsed = e._parse_llm_response(raw)
+    assert parsed["is_vulnerable"] is True
+    assert "{" in parsed["evidence"]  # nested braces inside a string value survived
+
+
+# ---- #4 response cache --------------------------------------------------------
+class _FakeClient:
+    def __init__(self):
+        self.calls = 0
+
+    def analyze_code(self, code, ctx):
+        self.calls += 1
+        return "" if code == "FAIL" else f"R:{code}"
+
+    def other(self):
+        return "delegated"
+
+
+def test_cache_hit_and_no_cache_of_failures(tmp_path):
+    fake = _FakeClient()
+    cc = CachedLLMClient(fake, str(tmp_path / "c"), model="m", enabled=True)
+    ctx = {"system_prompt": "s", "vuln_prompt": "v", "file_path": "F"}
+    assert cc.analyze_code("x", ctx) == cc.analyze_code("x", ctx)
+    assert fake.calls == 1  # second call served from cache
+    # empty responses must NOT be cached -> retried each time
+    cc.analyze_code("FAIL", ctx)
+    cc.analyze_code("FAIL", ctx)
+    assert fake.calls == 3
+    # unknown attributes delegate to the wrapped client
+    assert cc.other() == "delegated"
+
+
+def test_cache_resume_across_new_wrapper(tmp_path):
+    d = str(tmp_path / "c")
+    fake1 = _FakeClient()
+    ctx = {"system_prompt": "s", "vuln_prompt": "v", "file_path": "F"}
+    CachedLLMClient(fake1, d, model="m", enabled=True).analyze_code("x", ctx)
+    fake2 = _FakeClient()
+    assert CachedLLMClient(fake2, d, model="m", enabled=True).analyze_code("x", ctx) == "R:x"
+    assert fake2.calls == 0  # served from disk cache written by the first wrapper
+
+
+def test_cache_disabled_bypasses(tmp_path):
+    fake = _FakeClient()
+    cc = CachedLLMClient(fake, str(tmp_path / "c"), model="m", enabled=False)
+    ctx = {"system_prompt": "s", "vuln_prompt": "v", "file_path": "F"}
+    cc.analyze_code("x", ctx)
+    cc.analyze_code("x", ctx)
+    assert fake.calls == 2
+
+
+# ---- cross-language call graph mapping ----------------------------------------
+def test_path_to_class_java_and_smali(tmp_path):
+    import os
+    cg = CallGraphBuilder(str(tmp_path))
+    java = os.path.join(str(tmp_path), "sources", "com", "example", "Foo.java")
+    smali = os.path.join(str(tmp_path), "smali", "com", "example", "Foo.smali")
+    assert cg.path_to_class(java) == "com/example/Foo"
+    assert cg.path_to_class(smali) == "com/example/Foo"
+    assert cg.path_to_class(os.path.join(str(tmp_path), "other", "X.txt")) is None


### PR DESCRIPTION
# FEATURE & HARDENING UPDATE v1.2.0: LLM Response Cache, Scan Reliability & Cost Controls

This release adds a content-addressed **LLM response cache** (crash/rate-limit resume), makes concurrency and token limits **configurable**, closes several correctness gaps that could silently drop or mislabel findings, and cleans up noisy logging. Documentation was expanded to cover every new knob and CLI option.
