### PR TITLE
Version 1.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["master", "main"]
   pull_request:
+  workflow_dispatch:   # manual trigger for the paid Layer-2 job
 
 jobs:
   test:
@@ -24,6 +25,36 @@ jobs:
         # Layer-1 golden tests: detection-pattern coverage, engine pure functions,
         # and config invariants. No LLM / network required.
         run: pytest -q
+
+  semantic-test:
+    name: Golden Test Layer 2 (LLM — paid, opt-in)
+    runs-on: ubuntu-latest
+    # NEVER runs on a normal push/PR. Only via manual "Run workflow" (workflow_dispatch)
+    # or a pull request explicitly labeled `semantic-test`. This keeps LLM costs opt-in.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'semantic-test'))
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Run Layer 2 semantic golden test
+        # Prerequisites to actually execute (otherwise the harness SKIPS if the APK is absent):
+        #   - VulnerAppDLH.apk present at repo root (it is .gitignored — provide as a CI artifact/fixture)
+        #   - apktool + jadx installed on the runner
+        #   - a provider + key configured in config/settings.yaml (e.g. via scripts/ci/configurator.py
+        #     reading the OPENROUTER_API_KEY secret below)
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: pytest -m llm -q
 
   build-and-verify:
     name: Build & Sanity Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,13 @@ jobs:
         #   - VulnerAppDLH.apk present at repo root (it is .gitignored — provide as a CI artifact/fixture)
         #   - apktool + jadx installed on the runner
         #   - a provider + key configured in config/settings.yaml (e.g. via scripts/ci/configurator.py
-        #     reading the OPENROUTER_API_KEY secret below)
+        #     using INPUT_PROVIDER and INPUT_API_KEY from env below)
         env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        run: pytest -m llm -q
+          INPUT_PROVIDER: openrouter
+          INPUT_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          python scripts/ci/configurator.py
+          pytest -m llm -q
 
   build-and-verify:
     name: Build & Sanity Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run Layer 2 semantic golden test
         # Prerequisites to actually execute (otherwise the harness SKIPS if the APK is absent):
-        #   - VulnerAppDLH.apk present at repo root (it is .gitignored — provide as a CI artifact/fixture)
+        #   - VulnerAppDLHv2.apk present at repo root (it is .gitignored — provide as a CI artifact/fixture)
         #   - apktool + jadx installed on the runner
         #   - a provider + key configured in config/settings.yaml (e.g. via scripts/ci/configurator.py
         #     using INPUT_PROVIDER and INPUT_API_KEY from env below)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Features **Auto-Exploit Generation**, transforming from a passive scanner into a
 
 <p align="center">
   <img src="https://img.shields.io/badge/Security-Android-green" />
-  <img src="https://img.shields.io/badge/Drodi LLM Hunter-DLH-red" />
+  <img src="https://img.shields.io/badge/Droid LLM Hunter-DLH-red" />
   <img src="https://img.shields.io/badge/version-1.3.0-cyan" />
 </p>
 
@@ -147,7 +147,7 @@ Multi-stage pipeline: **Decompilation → Scope Filter → Risk Identification �
 |---------|---------|-------------|
 | `filter_mode` | `llm_only`, `static_only`, `hybrid` | `hybrid` |
 | `decompiler_mode` | `apktool`, `jadx`, `hybrid` | `hybrid` |
-| `provider` | `ollama`, `gemini`, `groq`, `openai`, `anthropic`, `openrouter`, `9router` | `anthropic` |
+| `provider` | `ollama`, `gemini`, `groq`, `openai`, `anthropic`, `openrouter`, `router9` | `anthropic` |
 
 → **[View Full Configuration Guide](document/CONFIGURATION.md)**
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Features **Auto-Exploit Generation**, transforming from a passive scanner into a
 **VulnerAppDLH** - a vulnerable Android application created specifically to test Droid-LLM-Hunter.
 **Link**: [VulnerAppDLH](https://github.com/roomkangali/VulnerAppDLH)
 
+### 📥 DLH Apk Fetcher
+
+**DLH Apk Fetcher** - a Python CLI tool for detecting Android devices connected via ADB, listing installed apps (name + version), showing currently running apps, searching packages, and downloading APKs into a structured local folder — preparing APK samples for security analysis with Droid-LLM-Hunter.
+**Link**: [dlh-apk-fetcher](https://github.com/roomkangali/dlh-apk-fetcher)
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Security-Android-green" />
+  <img src="https://img.shields.io/badge/Drodi LLM Hunter-DLH-red" />
+  <img src="https://img.shields.io/badge/version-1.3.0-cyan" />
+</p>
+
 <p align="center">
   <img src="logo/dlh-logo.png" width="1000">
 </p>
@@ -85,7 +96,7 @@ Features **Auto-Exploit Generation**, transforming from a passive scanner into a
 
 ## ✨ Features
 
-Droid LLM Hunter combines static analysis with LLM intelligence to detect Android vulnerabilities with high precision. Key capabilities include Staged Prompt Architecture, Hybrid Filter Modes, Call Graph Context Injection, OWASP MASVS enrichment, and Auto-Exploit Generation across 6 LLM providers.
+Droid LLM Hunter combines static analysis with LLM intelligence to detect Android vulnerabilities with high precision. Key capabilities include Staged Prompt Architecture, Hybrid Filter Modes, Call Graph Context Injection, OWASP MASVS enrichment, and Auto-Exploit Generation across 7 LLM providers (including **9Router**, a self-hosted multi-provider router).
 
 → **[View Full Feature List](document/FEATURES.md)**
 
@@ -124,7 +135,7 @@ Multi-stage pipeline: **Decompilation → Scope Filter → Risk Identification �
 
 ## 🛡️ Available Rules
 
-25 vulnerability rules covering SQL Injection, WebView XSS, Hardcoded Secrets, Intent Spoofing, Path Traversal, Insecure Deserialization, and more — all mapped to OWASP MASVS.
+26 vulnerability rules covering SQL Injection, WebView XSS, Hardcoded Secrets, Intent Spoofing, **Intent Redirection**, Path Traversal, Insecure Deserialization, and more — all mapped to OWASP MASVS. A separate **Library Hunter** mode (`--scan-libraries`) adds supply-chain/backdoor detection.
 
 → **[View All Rules](document/RULES.md)**
 
@@ -136,7 +147,7 @@ Multi-stage pipeline: **Decompilation → Scope Filter → Risk Identification �
 |---------|---------|-------------|
 | `filter_mode` | `llm_only`, `static_only`, `hybrid` | `hybrid` |
 | `decompiler_mode` | `apktool`, `jadx`, `hybrid` | `hybrid` |
-| `provider` | `ollama`, `gemini`, `groq`, `openai`, `anthropic`, `openrouter` | `anthropic` / `gemini` |
+| `provider` | `ollama`, `gemini`, `groq`, `openai`, `anthropic`, `openrouter`, `9router` | `anthropic` |
 
 → **[View Full Configuration Guide](document/CONFIGURATION.md)**
 
@@ -196,4 +207,4 @@ Next major version (v2.0) targets AI-Powered Dynamic Analysis with Frida & ADB i
 
 ---
 
-*Droid LLM Hunter drastically reduces noise using Context Awareness and Smart Filtering, LLMs (Artificial Intelligence) are probabilistic and can still make mistakes or "hallucinate". Treat the results as leads that require manual verification. The tool is designed to augment human intelligence, not replace it. Always verify findings manually!*
+*While Droid LLM Hunter uses Context Awareness and Smart Filtering to minimize noise, LLMs are inherently probabilistic and may occasionally hallucinate or misidentify vulnerabilities. Treat all results as leads requiring manual verification. This tool is built to augment human analysis not replace it.*

--- a/banner.txt
+++ b/banner.txt
@@ -2,7 +2,7 @@
 |    \ ___ ___|_|_| |___|  |  |  |  |     |___|  |  |_ _ ___| |_ ___ ___ 
 |  |  |  _| . | | . |___|  |__|  |__| | | |___|     | | |   |  _| -_|  _|
 |____/|_| |___|_|___|   |_____|_____|_|_|_|   |__|__|___|_|_|_| |___|_|  
-					       CLI Version 1.2.0
+					       CLI Version 1.3.0
 					      
 Droid-LLM-Hunter: A tool to scan for vulnerabilities in Android applications.                                                                                                                                          
 

--- a/config/knowledge_base/masvs_mapping.json
+++ b/config/knowledge_base/masvs_mapping.json
@@ -118,5 +118,10 @@
         "masvs_id": "MASVS-STORAGE-2",
         "description": "The app prevents leakage of sensitive data. Ensure no sensitive data is stored in resource files like strings.xml.",
         "reference": "https://mas.owasp.org/MASVS/controls/MASVS-STORAGE-2/"
+    },
+    "intent_redirection": {
+        "masvs_id": "MASVS-PLATFORM-1",
+        "description": "The app uses IPC mechanisms securely. Do not forward Intents received from untrusted callers without validating the target; a mutable/nested Intent enables confused-deputy attacks against non-exported components.",
+        "reference": "https://mas.owasp.org/MASVS/controls/MASVS-PLATFORM-1/"
     }
 }

--- a/config/prompts/app_summary_prompt.txt
+++ b/config/prompts/app_summary_prompt.txt
@@ -1,9 +1,16 @@
-Based on the following AndroidManifest.xml file and the summaries of the application's code, please provide a comprehensive summary of the application's capabilities.
-Focus on the main capabilities of the app, specifically calling out:
-- **Core Functionality**: What does the app do? (e.g. Banking, Social Media).
-- **Security Features**: Authentication methods (Biometric, PIN), cryptography usage.
-- **Data Handling**: What sensitive data is collected/stored?
-- **Permissions**: Notable dangerous permissions (Location, Contacts, SMS).
+You are writing the EXECUTIVE SUMMARY at the top of a security scan report, read by a security engineer who will also read the detailed per-file findings below it. Your job is to orient them in seconds, not to write a comprehensive app description.
+
+Based on the AndroidManifest.xml and code summaries below, write a summary following these rules:
+
+1. Be dense, not comprehensive. Report only security-relevant facts. Omit generic app description, marketing-style language, and disclaimers.
+2. Target 120-180 words total. Use short bullet points, not prose paragraphs, headers, or tables.
+3. Cover, in this order, only what applies (skip a line entirely if there is nothing notable):
+   - App purpose in one short line (what kind of app this is).
+   - Manifest red flags actually present: `debuggable=true`, `allowBackup=true`, cleartext traffic allowed, etc.
+   - Dangerous permissions actually requested (name them). If none, say "No dangerous permissions requested" in one line — do not enumerate the permissions that are absent.
+   - Exported attack surface: count of exported components, and name any with deep links, intent-filters, or otherwise reachable by other apps. This is the most valuable section — prioritize it.
+   - Sensitive data handled (secrets, credentials, local DB, files) only if evident from the summaries — one line, not a catalogue.
+4. Do not repeat the same fact in two sections. Do not add a closing warning/disclaimer paragraph.
 
 AndroidManifest.xml:
 ```xml

--- a/config/prompts/attack_surface_prompt.txt
+++ b/config/prompts/attack_surface_prompt.txt
@@ -1,6 +1,21 @@
-Based on the following AndroidManifest.xml file and the summaries of the application's code, please generate an attack surface map for the application.
-The attack surface map should be a list of all the points where an attacker can try to enter data or extract data from the application.
-Focus on exported components, deep links, network communication, file I/O, and user input.
+Based on the following AndroidManifest.xml file and the summaries of the application's code, extract a compact attack-surface INVENTORY.
+
+This is NOT a report — it is machine-readable data for a downstream tool to render. Do not explain, describe impact, or narrate. No prose, no markdown, no code fences, no commentary before or after. Output ONLY a single flat JSON object with exactly these keys:
+
+- exported_activities: array of short class names (not fully qualified) of exported activities.
+- exported_receivers: array of short class names of exported broadcast receivers.
+- exported_services: array of short class names of exported services.
+- exported_providers: array of short class names of exported content providers.
+- deep_links: array of objects, each with exactly three string fields: scheme, host, handler (the short class name that handles it). Use "*" for a wildcard host.
+- unprotected_broadcasts: array of exported broadcast action strings that have no permission attribute guarding them.
+- network: array of short lowercase tags for network/data technologies evident in the code summaries (e.g. "webview", "graphql", "http", "grpc"). Empty array if none evident.
+- file_io: boolean, true only if the code summaries show file read/write/extraction logic.
+- ipc: boolean, true only if the code summaries show Intent/PendingIntent forwarding, redirection, or dynamic broadcast beyond simple navigation.
+- deserialization: boolean, true only if the code summaries show object deserialization (e.g. ObjectInputStream).
+- reflection: boolean, true only if the code summaries show reflective class loading or invocation.
+- manifest_flags: object with boolean fields debuggable and allow_backup, set from the manifest's android:debuggable and android:allowBackup attributes (omit a field if the attribute is absent).
+
+Every array must contain only short identifiers or short tag strings — never sentences. If a key has nothing to report, use an empty array (or false for booleans, or an empty object for manifest_flags). Do not add any key not listed above.
 
 AndroidManifest.xml:
 ```xml

--- a/config/prompts/exploit_prompt.txt
+++ b/config/prompts/exploit_prompt.txt
@@ -1,18 +1,20 @@
-ROLE: Android Security Researcher & Exploit Developer.
-Your goal is to create a working Proof-of-Concept (PoC) script to demonstrate a specific vulnerability in Android code.
+AUTHORIZATION CONTEXT: This is an authorized, sandboxed security assessment. The application below was already scanned with the owner's consent, and the finding described here was already CONFIRMED by static analysis earlier in this same pipeline. Your task is to write a verification script that reproduces this already-identified finding so a remediation/QA team can observe its real-world impact and later confirm a fix — not to discover new vulnerabilities or target any system outside this already-scanned application.
+
+ROLE: Security Verification Engineer.
+Your goal is to write a verification script that reproduces the CONFIRMED finding below, so the remediation team can observe its real-world impact and later confirm the fix works.
 
 **STRICT CONSTRAINTS (ANTI-HALLUCINATION):**
 1. **NO INVENTED INTENTS**: Do NOT invent custom Intent Actions (e.g. "com.app.HACK_ACTION") unless they are explicitly visible in the Code or Manifest provided.
-2. **VERIFY VECTORS**: Use ONLY standard Android attack vectors (Deep Links, Exported Activities, Content Providers) unless you see a custom Receiver in the code.
-3. **NO MALWARE APKs**: Do not generate scripts that build/install other malicious APKs by compiling Java code. Focus on ADB interaction (am start, am broadcast).
+2. **VERIFY VECTORS**: Use ONLY standard Android IPC test vectors (Deep Links, Exported Activities, Content Providers) unless you see a custom Receiver in the code.
+3. **NO MALWARE APKs**: Do not generate scripts that build/install other APKs by compiling Java code. Focus on ADB interaction (am start, am broadcast) against the already-scanned target app only.
 4. **AUTO-VERIFICATION MANDATORY**: If generating a Python script, it MUST launch `adb logcat` in a background thread BEFORE sending the payload, and programmatically check for success indicators (Crash/Permission Denial) afterwards.
 
 **Instructions:**
 1.  **Analyze**: Read the provided Code Snippet and the Vulnerability Description carefully.
-2.  **Determine Format**: Choose the best format for the exploit:
+2.  **Determine Format**: Choose the best format for the verification script:
     *   **Bash (.sh)**: For Intent Spoofing, Activity launching (`adb shell am start`), Broadcasts, or Content Provider queries.
     *   **HTML (.html)**: For WebView XSS, Deep Link triggering (`<a href="scheme://...">`), or Intent Scheme URLs.
-    *   **Python (.py)**: For complex Logic Flaws, Broken Cryptography, or API exploitation that requires calculation or HTTP requests. *Must include Logcat verification.*
+    *   **Python (.py)**: For complex Logic Flaws, Broken Cryptography, or API interaction that requires calculation or HTTP requests. *Must include Logcat verification.*
     *   **Javascript (.js)**: For Frida Dynamic Hooking. Use this for Biometric Bypass, Root Detection Bypass, or SSL Pinning Bypass. Output the raw Frida script.
 3.  **Generate Code**: Write the complete, runnable code.
     *   If Bash, start with `#!/bin/bash` as the very first line.
@@ -28,14 +30,14 @@ Your goal is to create a working Proof-of-Concept (PoC) script to demonstrate a 
 - The output must end with the last line of actual code — no trailing ` ``` ` or explanation.
 - Reason: The output will be saved directly as an executable file and run automatically.
 
-**Vulnerability Context:**
+**Confirmed Finding (from static analysis):**
 - **Description**: {vulnerability_description}
 - **File**: {file_path}
 
 **Manifest Info (CRITICAL for Intent/Deep Link correctness):**
 {manifest_context}
 
-**Detected Hardcoded Secrets (Use these values in your exploit):**
+**Detected Hardcoded Secrets (Use these values in your script):**
 {detected_secrets}
 
 **Global Vulnerability Context (CROSS-COMPONENT CHAINING):**
@@ -48,4 +50,4 @@ Use the above Global Context to link vulnerabilities. If another component leaks
 {code_snippet}
 ```
 
-**Generate the PoC Code now:**
+**Generate the verification script now:**

--- a/config/prompts/summarize_prompt.txt
+++ b/config/prompts/summarize_prompt.txt
@@ -1,4 +1,4 @@
-Summarize the functionality of the following smali code snippet in a single sentence.
+Summarize the functionality of the following decompiled Android code (Java or Smali) in a single sentence.
 Focus on the high-level purpose AND explicitly highlight operations related to OWASP MASVS categories:
 1. MASVS-STORAGE: File I/O, SharedPreferences, Database (SQL/Room).
 2. MASVS-CRYPTO: Encryption, Decryption, Hashing, Key Management.
@@ -9,6 +9,6 @@ Focus on the high-level purpose AND explicitly highlight operations related to O
 7. MASVS-PRIVACY: Accessing Contacts, Location, Camera, or PII.
 
 Code:
-```smali
+```
 {code_snippet}
 ```

--- a/config/prompts/system_prompt.txt
+++ b/config/prompts/system_prompt.txt
@@ -20,7 +20,8 @@ You MUST provide your response in valid JSON format. Do NOT include any text out
 ```
 
 ### RULES FOR ANALYSIS
-1. Be conservative. Only mark `is_vulnerable` as `true` if you have distinct evidence code in the provided snippet.
-2. If the code is safe or the snippet is irrelevant to the rule, set `is_vulnerable` to `false` and "severity" to "Info".
-3. Do not assume context outside the provided snippet.
-4. Always populate `false_positive_analysis`, especially if `confidence` is not "High".
+1. Be conservative and evidence-driven. Mark `is_vulnerable` as `true` only when the snippet shows a concrete vulnerable pattern for the rule — an attacker-influenced source reaching a dangerous sink without adequate validation. Keyword presence alone is not enough.
+2. If the code is safe/validated or the snippet is irrelevant to the rule, set `is_vulnerable` to `false` and `severity` to "Info".
+3. Use ALL provided context — the code snippet PLUS any injected context (AndroidManifest excerpt, cross-reference / call-graph, caller arguments). Do not invent facts, but do reason with whatever context is given.
+4. Separate the flaw from its reachability — but ONLY when the vulnerable pattern is otherwise COMPLETE (attacker-influenced source → dangerous sink → no validation, all present) and the ONLY unknown is reachability/exploitability (e.g. whether the component is `exported`). In that case, keep `is_vulnerable: true`, set `confidence` to "Medium", and state the reachability assumption in `false_positive_analysis`. If the vulnerable pattern itself is incomplete or unclear, set `is_vulnerable: false`.
+5. Always populate `false_positive_analysis`, especially if `confidence` is not "High", and keep `evidence` to the minimal offending line(s).

--- a/config/prompts/vuln_rules/biometric_bypass.yaml
+++ b/config/prompts/vuln_rules/biometric_bypass.yaml
@@ -1,18 +1,22 @@
 name: "Biometric Authentication Bypass"
 description: "Detects potential weaknesses in the implementation of biometric authentication."
 prompt: |
-  Analyze the following smali code snippet for potential biometric authentication bypass vulnerabilities.
-  Specifically, look for implementations of `BiometricPrompt` and check if the `onAuthenticationSucceeded` callback is properly secured.
-  A vulnerability exists if the success callback can be easily triggered without actual biometric authentication, for example, by manipulating the application's control flow.
+  Analyze the following decompiled Android code (Java or Smali) for Biometric Authentication Bypass.
+
+  Vulnerability pattern:
+  - `BiometricPrompt` (or fingerprint APIs) is used, but the "authenticated" decision rests on a
+    CLIENT-SIDE flag/boolean that control-flow can reach without real authentication.
+  - Examples: success gated by `if (success || true)`, a mutable `isAuthenticated` field set outside
+    the `onAuthenticationSucceeded` callback, or empty/incorrect `onAuthenticationFailed` handling.
+  - No cryptographic binding (e.g. unlocking a Keystore key inside `onAuthenticationSucceeded`).
+
+  Not vulnerable if the sensitive action is cryptographically bound to a successful auth result.
 
   Code:
-  ```smali
+  ```
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there a potential biometric authentication bypass vulnerability in this code? If yes, explain how it could be exploited and suggest a remediation.
+  Context: file = {file_path}
 tags: ["biometric", "authentication", "bypass"]
 detection_pattern: "BiometricPrompt"

--- a/config/prompts/vuln_rules/deeplink_hijack.yaml
+++ b/config/prompts/vuln_rules/deeplink_hijack.yaml
@@ -1,19 +1,22 @@
 name: "Deep Link Hijacking & Open Redirect"
 description: "Detects potential deep link hijacking and open redirect vulnerabilities."
 prompt: |
-  Analyze the following AndroidManifest.xml snippet for vulnerabilities related to deep link hijacking and open redirects.
-  Look for <intent-filter> tags with an <action android:name="android.intent.action.VIEW" /> and a <data> tag with a scheme.
-  If a host is not specified or a wildcard is used, the deep link could be hijacked by a malicious application.
-  Also, check if the activity that handles the deep link properly validates the URL to prevent open redirects.
+  Analyze the following AndroidManifest.xml for Deep Link Hijacking / Open Redirect exposure.
+
+  Vulnerability pattern:
+  - An `<intent-filter>` with `android.intent.action.VIEW` + `BROWSABLE` declares a custom
+    `<data android:scheme=.../>` with NO host, a WILDCARD host (`android:host="*"`), or without
+    `android:autoVerify="true"` (App Links).
+  - A malicious app can register the same scheme/host and hijack the link (intercept tokens,
+    phishing). If the target activity then redirects using the link data, it is also an open redirect.
+
+  Recommend Android App Links (`autoVerify="true"` + Digital Asset Links) and strict scheme/host checks.
 
   AndroidManifest.xml:
   ```xml
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there a potential for deep link hijacking or open redirect in this manifest? If yes, explain the risk and provide a recommendation.
+  Context: file = {file_path}
 tags: ["manifest", "deeplink", "hijacking", "redirect"]
 detection_pattern: "android:autoVerify|android:scheme"

--- a/config/prompts/vuln_rules/deeplink_logic_bypass.yaml
+++ b/config/prompts/vuln_rules/deeplink_logic_bypass.yaml
@@ -10,7 +10,7 @@ prompt: |
   - Open Redirects: `intent.setData(Uri.parse(param))` or `webview.loadUrl(param)` without host validation.
   
   Code to Analyze:
-  ```java
+  ```
   {code_snippet}
   ```
   

--- a/config/prompts/vuln_rules/exported_components.yaml
+++ b/config/prompts/vuln_rules/exported_components.yaml
@@ -1,17 +1,21 @@
 name: "Exported Components without Permissions"
 description: "Detects exported components that are not protected by a permission."
 prompt: |
-  Analyze the following AndroidManifest.xml snippet for exported components (activities, services, receivers, providers) that are not protected by a permission.
-  An exported component without a permission can be accessed by any application on the device, which could lead to unauthorized access or denial of service.
+  Analyze the following AndroidManifest.xml for components exposed to other apps.
+
+  Vulnerability pattern:
+  - An `<activity>`, `<service>`, `<receiver>`, or `<provider>` has `android:exported="true"`
+    (or is implicitly exported via an `<intent-filter>`) AND has NO `android:permission` guard.
+  - Any app on the device can then invoke it → unauthorized access, intent injection, or DoS.
+
+  Not a finding: the LAUNCHER activity (MAIN/LAUNCHER) is expected to be exported; components
+  guarded by a signature-level `android:permission` are acceptable.
 
   AndroidManifest.xml:
   ```xml
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Are there any exported components without a permission in this manifest? If yes, list them and explain the risk.
+  Context: file = {file_path}
 tags: ["manifest", "exported", "permission"]
 detection_pattern: "android:exported=[\"']true[\"']"

--- a/config/prompts/vuln_rules/fragment_injection.yaml
+++ b/config/prompts/vuln_rules/fragment_injection.yaml
@@ -10,7 +10,7 @@ prompt: |
   - This allows attackers to load arbitrary fragments via `Intent.EXTRA_SHOW_FRAGMENT` (`:android:show_fragment`).
   
   Code to Analyze:
-  ```java
+  ```
   {code_snippet}
   ```
   

--- a/config/prompts/vuln_rules/graphql_injection.yaml
+++ b/config/prompts/vuln_rules/graphql_injection.yaml
@@ -1,22 +1,25 @@
 name: "GraphQL Injection"
 description: "Detects potential GraphQL injection vulnerabilities."
 prompt: |
-  Analyze the following smali code snippet for potential GraphQL injection vulnerabilities.
-  Specifically, look for GraphQL queries that are constructed by concatenating user input.
-  This could allow an attacker to manipulate the query and access unauthorized data.
+  Analyze the following decompiled Android code (Java or Smali) for GraphQL Injection.
+
+  Vulnerability pattern:
+  - A GraphQL query/mutation STRING is assembled at runtime by concatenating a TAINTED value
+    (user input, Intent extra, deep-link param) directly into the query body.
+  - This lets an attacker alter the query structure (inject fields, arguments, or nested queries)
+    to reach unauthorized data — instead of using GraphQL variables (`$var`) with a separate args map.
+
+  Not vulnerable if the query is static or user values are passed only through GraphQL variables.
 
   Code:
-  ```smali
+  ```
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there a potential GraphQL injection vulnerability in this code? If yes, explain how it could be exploited and suggest a remediation.
+  Context: file = {file_path}
 tags: ["graphql", "injection", "api"]
 keywords:
   - "graphql"
   - "query"
   - "GraphQL"
-detection_pattern: "(?i)(graphql.*(query|mutation)|query.*=.*[\"']|mutation.*=.*[\"']|execute.*query)"
+detection_pattern: "(?i)(graphql|(query|mutation)\\s*\\{)"

--- a/config/prompts/vuln_rules/hardcoded_secrets.yaml
+++ b/config/prompts/vuln_rules/hardcoded_secrets.yaml
@@ -1,17 +1,22 @@
 name: "Hardcoded Secrets"
 description: "Detects hardcoded API keys, passwords, or other secrets in the code."
 prompt: |
-  Analyze the following Java code snippet for hardcoded secrets.
-  Look for variables that store sensitive information like API keys, credentials, or encryption keys directly in the source code.
+  Analyze the following decompiled Android code (Java or Smali) for Hardcoded Secrets.
+
+  Vulnerability pattern:
+  - A sensitive value is embedded directly in code: API key, cloud credential (AWS `AKIA...`),
+    OAuth/JWT token (`eyJ...`), password, PEM private key, or signing/encryption key material.
+  - Held in a constant/field/string literal (or persisted from one). Anyone can extract it by
+    decompiling the APK.
+
+  Ignore obvious placeholders/dummies ("your_api_key", "changeme", "example", "REPLACE_ME").
+  Report the specific secret(s); recommend BuildConfig/NDK/backend-proxy or the Android Keystore.
 
   Code:
-  ```java
+  ```
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Are there any hardcoded secrets in this code? If yes, identify them and explain why this is a security risk. Recommend using the Android Keystore system or obfuscation techniques.
+  Context: file = {file_path}
 tags: ["secrets", "credentials", "hardcoded"]
 detection_pattern: "(?i)(AIza[0-9A-Za-z-_]{35}|AKIA[0-9A-Z]{16}|const-string.*(api_key|password|secret|token)|(api_key|password|secret|token).*=.*[\"'])"

--- a/config/prompts/vuln_rules/insecure_deserialization.yaml
+++ b/config/prompts/vuln_rules/insecure_deserialization.yaml
@@ -9,7 +9,7 @@ prompt: |
   - If the class being deserialized is not validated (e.g., look-ahead deserialization), it can lead to RCE.
   
   Code to Analyze:
-  ```java
+  ```
   {code_snippet}
   ```
   
@@ -25,5 +25,5 @@ keywords:
   - "ObjectInputStream"
   - "readObject"
   - "getSerializableExtra"
-detection_pattern: "ObjectInputStream.*\\.readObject"
+detection_pattern: "ObjectInputStream.*(?:\\.|->)readObject"
 tags: ["deserialization", "rce", "serializable"]

--- a/config/prompts/vuln_rules/insecure_file_permissions.yaml
+++ b/config/prompts/vuln_rules/insecure_file_permissions.yaml
@@ -1,12 +1,14 @@
 name: "Insecure File Permissions"
 description: "Detects files created with world-readable or world-writable permissions."
 prompt: |
-  Analyze the following smali code snippet for insecure file permissions.
-  Specifically, look for `openFileOutput` calls where the mode is `MODE_WORLD_READABLE` or `MODE_WORLD_WRITABLE`.
-  These modes are deprecated and can lead to security vulnerabilities.
+  Analyze the following decompiled Android code (Java or Smali) for insecure file permissions.
+  Specifically, look for:
+  - `openFileOutput` calls where the mode is `MODE_WORLD_READABLE` / `MODE_WORLD_WRITABLE` (or the raw int `1`/`2`).
+  - `File.setReadable(true, false)` or `File.setWritable(true, false)` — the second arg `false` means "not owner-only", i.e. readable/writable by ALL apps.
+  These make the file accessible to other apps on the device and can leak sensitive data.
 
   Code:
-  ```smali
+  ```
   {code_snippet}
   ```
 
@@ -15,4 +17,4 @@ prompt: |
 
   Is there an insecure file permission vulnerability in this code? If yes, explain the risk and suggest a remediation.
 tags: ["storage", "permission", "file"]
-detection_pattern: "MODE_WORLD_READABLE|MODE_WORLD_WRITABLE"
+detection_pattern: "MODE_WORLD_READABLE|MODE_WORLD_WRITABLE|set(Readable|Writable)\\s*\\(\\s*true\\s*,\\s*false"

--- a/config/prompts/vuln_rules/insecure_random_number_generation.yaml
+++ b/config/prompts/vuln_rules/insecure_random_number_generation.yaml
@@ -1,18 +1,22 @@
 name: "Insecure Random Number Generation"
 description: "Detects the use of insecure random number generators."
 prompt: |
-  Analyze the following smali code snippet for the use of insecure random number generators.
-  Specifically, look for the use of `Ljava/util/Random;`. This class is not cryptographically secure and should not be used for security-sensitive applications.
-  Instead, `Ljava/security/SecureRandom;` should be used.
+  Analyze the following decompiled Android code (Java or Smali) for Insecure Random Number Generation.
+
+  Vulnerability pattern:
+  - `java.util.Random` (Smali `Ljava/util/Random;`) or a time-seeded PRNG is used to produce a value
+    used in a SECURITY context — session token, OTP, password-reset token, nonce, ID, key material.
+  - `java.util.Random` is predictable (not cryptographically secure); `java.security.SecureRandom`
+    must be used for such values.
+
+  Not vulnerable if `Random` is used only for non-security purposes (animations, shuffling UI, jitter).
+  Judge by how the generated value is USED.
 
   Code:
-  ```smali
+  ```
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there an insecure random number generation vulnerability in this code? If yes, explain the risk and suggest a remediation.
+  Context: file = {file_path}
 tags: ["crypto", "random"]
 detection_pattern: "(Ljava/util/Random;|java\\.util\\.Random|new Random\\()"

--- a/config/prompts/vuln_rules/insecure_storage.yaml
+++ b/config/prompts/vuln_rules/insecure_storage.yaml
@@ -1,18 +1,21 @@
 name: "Insecure Storage"
 description: "Detects insecure storage of sensitive data in SharedPreferences and world-readable files."
 prompt: |
-  Analyze the following smali code snippet for insecure storage vulnerabilities.
-  Specifically, look for the use of `SharedPreferences` with `MODE_WORLD_READABLE` and the creation of world-readable files.
-  A vulnerability exists if sensitive data is stored in a way that allows other applications to access it.
+  Analyze the following decompiled Android code (Java or Smali) for Insecure Storage of sensitive data.
+
+  Vulnerability pattern:
+  - SENSITIVE data (password, token, API key, PII, credentials) is written in PLAINTEXT to
+    `SharedPreferences`, a file, or a database — with no encryption.
+  - Or the store is world-accessible (`MODE_WORLD_READABLE`/`WRITEABLE`, or a world-readable file).
+  - Secure alternative: `EncryptedSharedPreferences` / Jetpack Security, or the Android Keystore.
+
+  Focus on WHAT is stored: plaintext secrets are the issue. Storing non-sensitive prefs is fine.
 
   Code:
-  ```smali
+  ```
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there a potential insecure storage vulnerability in this code? If yes, explain how it could be exploited and suggest a remediation.
+  Context: file = {file_path}
 tags: ["storage", "sharedpreferences", "world-readable"]
 detection_pattern: "(?i)(SharedPreferences|getSharedPreferences|openFileOutput|MODE_WORLD_READABLE|MODE_WORLD_WRITABLE)"

--- a/config/prompts/vuln_rules/insecure_webview.yaml
+++ b/config/prompts/vuln_rules/insecure_webview.yaml
@@ -1,18 +1,22 @@
 name: "Insecure WebView Configuration"
 description: "Detects insecure WebView configurations, such as the use of addJavascriptInterface and file access."
 prompt: |
-  Analyze the following smali code snippet for insecure WebView configurations.
-  Specifically, look for the use of `addJavascriptInterface` and settings that allow file access from file URLs (`setAllowFileAccessFromFileURLs`) or universal access from file URLs (`setAllowUniversalAccessFromFileURLs`).
-  A vulnerability exists if a malicious script can be executed through the WebView, potentially leading to sensitive data leakage or remote code execution.
+  Analyze the following decompiled Android code (Java or Smali) for Insecure WebView Configuration.
+
+  Vulnerability pattern (any of):
+  - `addJavascriptInterface(obj, ...)` exposing native methods to web content (esp. with JS enabled).
+  - `setAllowUniversalAccessFromFileURLs(true)` or `setAllowFileAccessFromFileURLs(true)` — lets
+    `file://` pages read arbitrary local files (local file / cookie theft).
+  - `setAllowFileAccess(true)` combined with loading untrusted/remote or intent-supplied URLs.
+
+  Risk rises when the WebView also loads attacker-influenced content (remote URL, deep-link, file).
+  Not vulnerable if these dangerous settings are absent or explicitly disabled.
 
   Code:
-  ```smali
+  ```
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there a potential insecure WebView configuration in this code? If yes, explain how it could be exploited and suggest a remediation.
+  Context: file = {file_path}
 tags: ["webview", "javascriptinterface", "fileaccess"]
 detection_pattern: "addJavascriptInterface|setAllow(File|Universal)AccessFromFileURLs\\(true\\)"

--- a/config/prompts/vuln_rules/intent_redirection.yaml
+++ b/config/prompts/vuln_rules/intent_redirection.yaml
@@ -1,0 +1,37 @@
+name: "Intent Redirection"
+description: "Detects confused-deputy Intent redirection where an exported component forwards an attacker-supplied nested Intent without validation."
+prompt: |
+  Analyze the following decompiled Android code (Java or Smali) for an Intent Redirection (confused deputy) vulnerability.
+
+  Vulnerability pattern:
+  - An exported component extracts a NESTED Intent from an untrusted caller, e.g.
+    `Intent forward = intent.getParcelableExtra("...")` (or a Bundle `getParcelable`).
+  - It then forwards that Intent to a sink WITHOUT validating its target/component:
+    `startActivity(forward)`, `startActivityForResult(...)`, `startService(...)`, or `sendBroadcast(...)`.
+  - Because the forward runs with THIS app's identity, an attacker can reach the app's
+    non-exported components or relay granted URI permissions (READ/WRITE_URI_PERMISSION).
+
+  Tainted source: the nested Intent comes from `getIntent()` / a received Intent extra
+  (`getParcelableExtra` / `getParcelable`) — i.e. it is controlled by the calling app.
+
+  NOT a finding if:
+  - The forwarded Intent is built internally (explicit component/class set by this app), not taken from an extra.
+  - The target is validated against an allowlist, the component/package is explicitly set to a trusted value,
+    or the caller's identity is checked before forwarding.
+  - The receiving component is not exported and cannot be reached by other apps.
+
+  Code to Analyze:
+  ```
+  {code_snippet}
+  ```
+
+  Context:
+  - File Path: {file_path}
+keywords:
+  - "getParcelableExtra"
+  - "startActivity"
+  - "startService"
+  - "sendBroadcast"
+  - "EXTRA_INTENT"
+tags: ["intents", "ipc", "redirection", "confused_deputy", "privilege_escalation"]
+detection_pattern: "getParcelableExtra\\s*[(<]"

--- a/config/prompts/vuln_rules/intent_spoofing.yaml
+++ b/config/prompts/vuln_rules/intent_spoofing.yaml
@@ -1,18 +1,21 @@
 name: "Intent Spoofing"
 description: "Detects exported components that are not properly protected and could be vulnerable to intent spoofing."
 prompt: |
-  Analyze the following AndroidManifest.xml snippet for vulnerabilities related to intent spoofing.
-  Specifically, look for exported activities, services, or receivers that do not have a permission attribute or have a permission that is not strong enough.
-  An attacker could send an intent to these components and perform unauthorized actions.
+  Analyze the following AndroidManifest.xml for Intent Spoofing exposure.
+
+  Vulnerability pattern:
+  - An exported `<receiver>` (or activity/service) declares an `<intent-filter>` for a custom action
+    but has NO `android:permission` (or only a `normal`-level one).
+  - A malicious app can then SPOOF that Intent/broadcast to trigger a sensitive action (e.g. a fake
+    "password reset" / state change), because the component trusts the action without verifying the sender.
+
+  Recommend a signature-level permission, or `LocalBroadcastManager` for internal-only events.
 
   AndroidManifest.xml:
   ```xml
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there an Intent Spoofing vulnerability in this manifest? If yes, explain the risk and provide a recommendation.
+  Context: file = {file_path}
 tags: ["manifest", "intent", "spoofing"]
 detection_pattern: "android:exported=[\"']true[\"']"

--- a/config/prompts/vuln_rules/jetpack_compose_security.yaml
+++ b/config/prompts/vuln_rules/jetpack_compose_security.yaml
@@ -1,12 +1,12 @@
 name: "Jetpack Compose Security"
 description: "Detects potential security issues in Jetpack Compose code."
 prompt: |
-  Analyze the following smali code snippet for security best practices in Jetpack Compose.
+  Analyze the following decompiled Android code (Java or Smali) for security best practices in Jetpack Compose.
   Specifically, look for Composable functions that might be vulnerable to screen capture.
   Check if `FLAG_SECURE` is used to prevent screen content from being captured.
 
   Code:
-  ```smali
+  ```
   {code_snippet}
   ```
 

--- a/config/prompts/vuln_rules/library_vulnerability.yaml
+++ b/config/prompts/vuln_rules/library_vulnerability.yaml
@@ -13,7 +13,7 @@ prompt: |
   5.  **Unsafe Web Bridges:** `addJavascriptInterface` exposing native methods to unchecked web content.
 
   **Code to Analyze:**
-  ```java
+  ```
   {code_snippet}
   ```
 

--- a/config/prompts/vuln_rules/path_traversal.yaml
+++ b/config/prompts/vuln_rules/path_traversal.yaml
@@ -1,18 +1,22 @@
 name: "Path Traversal"
 description: "Detects path traversal vulnerabilities in ContentProviders."
 prompt: |
-  Analyze the following smali code snippet for path traversal vulnerabilities.
-  Specifically, look for the use of `ContentProvider` and check if the `openFile` method is properly implemented to prevent path traversal attacks.
-  A vulnerability exists if a malicious user can access files outside of the intended directory.
+  Analyze the following decompiled Android code (Java or Smali) for Path Traversal (Local File Inclusion).
+
+  Vulnerability pattern:
+  - A file path is built from a TAINTED value (Intent extra, deep-link/query param, ContentProvider
+    `openFile(uri)` segment, user text) and used in `new File(dir, name)`, `FileInputStream`,
+    `FileOutputStream`, or a `ContentProvider.openFile` — WITHOUT sanitizing `..` / absolute paths.
+  - The classic guard is MISSING: no `getCanonicalPath()` check confirming the resolved file stays
+    inside the intended base directory.
+
+  Not vulnerable if the filename is constant, or a canonical-path/allowlist check is enforced.
 
   Code:
-  ```smali
+  ```
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there a potential path traversal vulnerability in this code? If yes, explain how it could be exploited and suggest a remediation.
+  Context: file = {file_path}
 tags: ["storage", "contentprovider", "path-traversal"]
-detection_pattern: "openFile"
+detection_pattern: "(openFile|FileInputStream|FileOutputStream)\\s*\\("

--- a/config/prompts/vuln_rules/pending_intent_hijacking.yaml
+++ b/config/prompts/vuln_rules/pending_intent_hijacking.yaml
@@ -9,7 +9,7 @@ prompt: |
   - IMPORTANT: In modern Android, checking for `FLAG_MUTABLE` or absence of `FLAG_IMMUTABLE` is critical.
   
   Code to Analyze:
-  ```java
+  ```
   {code_snippet}
   ```
   
@@ -26,5 +26,5 @@ keywords:
   - "FLAG_MUTABLE"
   - "getActivity"
   - "getService"
-detection_pattern: "PendingIntent\\.(getActivity|getService|getBroadcast).*FLAG_MUTABLE"
+detection_pattern: "PendingIntent(?:\\.|;->)(getActivity|getService|getBroadcast).*(FLAG_MUTABLE|33554432)"
 tags: ["intents", "privilege_escalation", "pending_intent"]

--- a/config/prompts/vuln_rules/sql_injection.yaml
+++ b/config/prompts/vuln_rules/sql_injection.yaml
@@ -1,17 +1,23 @@
 name: "SQL Injection"
 description: "Detects potential SQL Injection vulnerabilities in database queries."
 prompt: |
-  Analyze the following Java code snippet for SQL Injection vulnerabilities.
-  Specifically, look for cases where user input is concatenated directly into SQL queries executed via `rawQuery`, `execSQL`, or similar methods.
+  Analyze the following decompiled Android code (Java or Smali) for SQL Injection.
+
+  Vulnerability pattern:
+  - A query runs via `rawQuery(...)`, `execSQL(...)`, `query(...)`, or a similar raw-SQL API.
+  - The SQL string is built by concatenation/interpolation that includes a TAINTED value —
+    user input from an EditText, `getIntent()` extra, deep-link parameter, file, or network.
+  - No parameterized placeholders (`?` + `selectionArgs`/bound args) are used for that value.
+
+  Tainted source: trace whether the concatenated value can be attacker-controlled. If it is a
+  constant or comes only from trusted app state, it is NOT vulnerable.
 
   Code:
-  ```java
+  ```
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there a SQL Injection vulnerability in this code? If yes, explain how to exploit it and provide a remediated code snippet using parameterized queries.
+  Context: file = {file_path}
+  Put the exploitation in attack_scenario and the parameterized-query fix in recommendation.
 tags: ["sql", "database", "injection"]
 detection_pattern: "(rawQuery|execSQL)\\s*\\("

--- a/config/prompts/vuln_rules/universal_logic_flaw.yaml
+++ b/config/prompts/vuln_rules/universal_logic_flaw.yaml
@@ -1,29 +1,40 @@
 name: "Conceptual Logic Flaw Detection"
 description: "Detects sophisticated logic flaws in Android Internals (IPC/Reflection) and Business Logic (Financial/Auth)."
 prompt: |
-  You are an Advanced Android Security Researcher specializing in LOGIC FLAWS.
-  
-  Analyze the following code snippet for subtle CONCEPTUAL Vulnerabilities in:
-  1. **Low-Level Android:** IPC (`Parcel`, `Serializable`, `Intent`), Reflection (`Method.invoke`), Deep Link handling.
-  2. **High-Level Business Logic:** Payment bypasses, Admin privilege escalation, Transaction manipulation.
+  You are an Advanced Android Security Researcher specializing in CONCEPTUAL LOGIC FLAWS —
+  the kind that no signature/keyword rule can catch. Focus ONLY on flawed trust and control flow.
 
-  **Devil's Advocate Questions (Challenge the Code):**
-  - **Logic Bypass:** Can I manipulate inputs to skip the critical `if (securityCheck)` block? (Race Conditions).
-  - **Deserialization:** Does it accept `Serializable`/`Parcelable` from an external Intent? (Object Injection risk).
-  - **Reflection:** Is `Method.invoke` or `Class.forName` used with user-controlled strings? (RCE Risk).
-  - **Financial Logic:** Can I send a negative number to a payment function? Is the "Amount" trusted from client input?
-  
+  IN SCOPE (report these):
+  - Client-side trust of a security decision: an `isVip` / `isAdmin` / `isPaid` / `isAuthenticated`
+    boolean or role flag that the client can flip, or that gates access with no server-side verification.
+  - Authentication / biometric bypass via control flow: the auth result is ignored, hard-coded, or
+    overridden (e.g. `if (success || true)`, or "success" set outside the real auth callback).
+  - IPC / Intent trust: an exported component performs a sensitive action from incoming Intent data
+    (`getStringExtra`, deep-link params) with no caller identity / permission check.
+  - Business-logic bypass: negative/overflow amounts, price/quantity/role trusted from the client,
+    or a race condition / order-of-operations flaw around a critical check.
+
+  OUT OF SCOPE — do NOT report these here (dedicated rules already own them):
+  - SQL or GraphQL injection, hardcoded secrets, insecure storage / file permissions, path traversal,
+    standard WebView misconfiguration, insecure deserialization, unsafe reflection.
+  - If the ONLY problem in the snippet is one of the above, set is_vulnerable=false for THIS rule
+    (another rule will report it). Only flag a genuine trust/logic flaw as defined above.
+
   Code to Analyze:
-  ```java
+  ```
   {code_snippet}
   ```
 
   Context:
   - File: {file_path}
 
-  If you find a Logic Flaw, explain the "Kill Chain" (How to trigger it). If the code is robust, say "Safe".
+  Set is_vulnerable=true ONLY for a genuine conceptual / trust / business-logic flaw; describe the
+  kill chain in the JSON fields. Otherwise set is_vulnerable=false.
 tags: ["logic_flaw", "ipc", "reflection", "business_logic", "serialization"]
-detection_pattern: "(Parcel|Serializable|Method\\.invoke|Class\\.forName|payment|admin|transfer|balance|shouldOverrideUrlLoading)"
+# [v1.3.0 T3.4a] NO detection_pattern on purpose: this rule is LLM-EXCLUSIVE / conceptual
+# (per VULNER_DLH.md). A narrow pattern made per-rule gating (#1) skip real logic flaws
+# like CryptoActivity's isVip/||true (baseline recall gap). With no pattern it runs on every
+# risky file that survived the global scope/keyword filter — its intended design.
 keywords:
   - "Parcel"
   - "Serializable"

--- a/config/prompts/vuln_rules/unsafe_reflection.yaml
+++ b/config/prompts/vuln_rules/unsafe_reflection.yaml
@@ -10,7 +10,7 @@ prompt: |
   - Pattern: `String cls = intent.getStringExtra("class"); Class.forName(cls);`
   
   Code to Analyze:
-  ```java
+  ```
   {code_snippet}
   ```
   
@@ -28,4 +28,4 @@ keywords:
   - "ClassLoader"
   - "getStringExtra"
 tags: ["reflection", "rce", "code_execution"]
-detection_pattern: "(?i)(Class\\.forName|Method\\.invoke|ClassLoader\\.loadClass)"
+detection_pattern: "(?i)(Class(?:\\.|;->)forName|Method(?:\\.|;->)invoke|ClassLoader(?:\\.|;->)loadClass)"

--- a/config/prompts/vuln_rules/webview_deeplink.yaml
+++ b/config/prompts/vuln_rules/webview_deeplink.yaml
@@ -1,18 +1,23 @@
 name: "WebView via DeepLink"
 description: "Detects potential WebView vulnerabilities exposed via deep links."
 prompt: |
-  Analyze the following AndroidManifest.xml snippet for vulnerabilities related to deep links and WebViews.
-  Specifically, look for <intent-filter> tags with an <action android:name="android.intent.action.VIEW" /> that open an activity containing a WebView.
-  If you find such a deep link, check if the corresponding activity validates the URL loaded into the WebView.
-  A vulnerability exists if the WebView loads a URL from an intent without proper validation, which could lead to XSS or other attacks.
+  Analyze the following AndroidManifest.xml for a deep link that can drive a WebView.
+
+  Vulnerability pattern:
+  - An `<activity>` has an `<intent-filter>` with `android.intent.action.VIEW` + `BROWSABLE` and a
+    `<data android:scheme=.../>` (a deep link), AND that activity hosts a WebView.
+  - If the activity loads a URL taken from the incoming Intent (`getIntent().getData()`, a query
+    parameter, etc.) into `webView.loadUrl(...)` WITHOUT validating scheme/host against an allowlist,
+    an attacker can drive the WebView to arbitrary content (open redirect / XSS / phishing).
+
+  Recommend validating scheme + host before loading, and disabling unneeded WebView features.
 
   AndroidManifest.xml:
   ```xml
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
+  Context: file = {file_path}
 
   Is there a WebView via DeepLink vulnerability in this manifest? If yes, explain the risk and provide a recommendation.
 tags: ["manifest", "deeplink", "webview"]

--- a/config/prompts/vuln_rules/webview_file_access.yaml
+++ b/config/prompts/vuln_rules/webview_file_access.yaml
@@ -10,7 +10,7 @@ prompt: |
   - Risk: If an attacker can load a local file (e.g. via an exposed Component or XSS in a local file), they can read other local files or databases (Cookies).
   
   Code to Analyze:
-  ```java
+  ```
   {code_snippet}
   ```
   

--- a/config/prompts/vuln_rules/webview_xss.yaml
+++ b/config/prompts/vuln_rules/webview_xss.yaml
@@ -1,17 +1,23 @@
 name: "WebView XSS"
 description: "Detects potential Cross-Site Scripting (XSS) vulnerabilities in WebViews."
 prompt: |
-  Analyze the following Java code snippet for WebView XSS vulnerabilities.
-  Look for WebViews where JavaScript is enabled (`setJavaScriptEnabled(true)`) and untrusted content is loaded via `loadUrl` or `loadData`.
+  Analyze the following decompiled Android code (Java or Smali) for WebView XSS.
+
+  Vulnerability pattern:
+  - JavaScript is enabled (`setJavaScriptEnabled(true)`).
+  - AND attacker-influenced content is loaded: `loadUrl(...)` / `loadData(...)` /
+    `loadDataWithBaseURL(...)` with a value from an Intent/deep-link/network/user input, or an
+    `addJavascriptInterface(...)` bridge exposed to such content.
+  - No sanitization / scheme-host allowlisting of the loaded URL or HTML.
+
+  Tainted source: trace whether the loaded URL/HTML can be attacker-controlled. Loading a fixed,
+  trusted asset with JS enabled is not by itself XSS.
 
   Code:
-  ```java
+  ```
   {code_snippet}
   ```
 
-  Context:
-  - File Path: {file_path}
-
-  Is there a potential XSS vulnerability in this WebView implementation? If yes, explain the risk and recommend mitigation strategies like disabling JavaScript if not needed, or sanitizing input.
+  Context: file = {file_path}
 tags: ["webview", "xss", "javascript"]
 detection_pattern: "setJavaScriptEnabled\\(true\\)|addJavascriptInterface"

--- a/config/prompts/vuln_rules/zip_slip.yaml
+++ b/config/prompts/vuln_rules/zip_slip.yaml
@@ -22,7 +22,7 @@ prompt: |
     ```
   
   Code to Analyze:
-  ```java
+  ```
   {code_snippet}
   ```
   
@@ -39,5 +39,5 @@ keywords:
   - "ZipEntry"
   - "getCanonicalPath"
   - "ZipFile"
-detection_pattern: "ZipEntry.*\\.getName"
+detection_pattern: "ZipEntry.*(?:\\.|->)getName"
 tags: ["zip_slip", "path_traversal", "file_overwrite"]

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,7 +1,7 @@
 # Droid-LLM-Hunter Settings
 analysis:
   decompiler_mode: hybrid # hybrid, apktool, or jadx
-  filter_mode: static_only # static_only, llm_only, or hybrid
+  filter_mode: hybrid # static_only, llm_only, or hybrid
   generate_attack_surface_map: true # Generate attack surface map
   generate_exploit: false # Generate PoC scripts for vulnerabilities
   scan_libraries: false # If true, includes 3rd party libraries in scan scope.
@@ -20,7 +20,7 @@ jadx:
 
 # LLM Configuration
 llm:
-  provider: ollama # or "ollama" or "gemini" or "groq" or "openai" or "anthropic"
+  provider: ollama # or "ollama" or "gemini" or "groq" or "openai" or "anthropic" or "openrouter" or "router9"
   anthropic_api_key: ANTHROPIC_API_KEY # Replace with your Anthropic API key
   anthropic_model: claude-sonnet-4-20250514 # default model for anthropic or "claude-sonnet-4-5-20250929"
   gemini_api_key: GEMINI_API_KEY # Replace with your Gemini API key
@@ -32,8 +32,13 @@ llm:
   openai_api_key: OPENAI_API_KEY # Replace with your OpenAI API key
   openai_model: gpt-4-turbo # default model for openai or "gpt-4-turbo"
   openrouter_api_key: OPENROUTER_API_KEY # Replace with your OpenRouter API key
-  openrouter_model: google/gemini-2.5-flash #  default model for openrouter or "google/gemini-2.5-pro"
-  max_tokens: 4096 # [#6] Max output tokens per LLM call (raise if JSON/exploit output gets cut off)
+  openrouter_model: moonshotai/kimi-k3 #  default model for openrouter or "google/gemini-2.5-pro"
+  router9_api_key: 9ROUTER_API_KEY # Replace with your 9Router API key
+  router9_base_url: http://localhost:20128/v1/chat/completions # self-hosted; change host/port to match your instance
+  router9_model: cx/gpt-5.6-sol # default model for router9 (provider-prefixed, e.g. "gc/gemini-2.5-pro", "cx/gpt-5.6-sol"). If it's a reasoning model, raise max_tokens (reasoning tokens count against it)
+  exploit_provider: anthropic # --generate-exploit routed here (router9/jem-glm-5.2 returned empty for exploit-gen, confirmed live); reuses anthropic_api_key/anthropic_model above
+  exploit_model: null # optional: override the model used for exploit-gen on exploit_provider (or on `provider`, if exploit_provider is unset)
+  max_tokens: 8192 # [#6] Max output tokens per LLM call (raise if JSON/exploit output gets cut off)
 
 # Analysis Rules
 # Enable or disable specific vulnerability checks
@@ -46,11 +51,12 @@ rules:
   graphql_injection: false # Dynamic GraphQL query construction
   hardcoded_secrets: false # Critical API Keys & Secrets in code
   hardcoded_secrets_xml: false # Secrets hidden in strings.xml
-  insecure_deserialization: true # RCE via ObjectInputStream.readObject
+  insecure_deserialization: false # RCE via ObjectInputStream.readObject
   insecure_file_permissions: false # World-readable files/SharedPreferences
   insecure_random_number_generation: false # Weak PRNG (java.util.Random)
   insecure_storage: false # Plain-text credentials in XML/Files
   insecure_webview: false # Dangerous WebSettings (FileAccess)
+  intent_redirection: true # Confused-deputy: forwarding attacker's nested Intent
   intent_spoofing: false # Unauthorized Broadcast Receivers
   jetpack_compose_security: false # Debug flags in Compose UI
   path_traversal: false # Local File Inclusion via ContentProvider

--- a/core/config_loader.py
+++ b/core/config_loader.py
@@ -22,7 +22,19 @@ class LLMSettings(BaseModel):
     # OpenRouter
     openrouter_model: Optional[str] = None
     openrouter_api_key: Optional[str] = None
+    # 9Router (self-hosted, OpenAI-compatible multi-provider router; field prefix is
+    # "router9" because Python/Pydantic identifiers can't start with a digit)
+    router9_model: Optional[str] = None
+    router9_api_key: Optional[str] = None
+    router9_base_url: Optional[str] = "http://localhost:20128/v1/chat/completions"
     max_tokens: int = 4096  # [#6] Max output tokens per LLM call (avoid truncated JSON/exploit)
+    # [v1.3.0] Route --generate-exploit to a DIFFERENT provider/model than scanning.
+    # Some models refuse or silently return empty output for exploit/PoC generation
+    # even with authorized-assessment framing in the prompt, while being fine for
+    # vulnerability analysis. Both optional; unset means "use the main `provider`/its
+    # own default model", so this is fully opt-in and backward compatible.
+    exploit_provider: Optional[str] = None   # e.g. "anthropic" — reuses that provider's own api_key/model fields above
+    exploit_model: Optional[str] = None      # optional model override on exploit_provider (or on `provider`, if exploit_provider is unset)
 
 class ApktoolSettings(BaseModel):
     path: Optional[str] = None
@@ -58,6 +70,7 @@ class RulesSettings(BaseModel):
     insecure_random_number_generation: bool
     insecure_storage: bool
     insecure_webview: bool
+    intent_redirection: bool
     intent_spoofing: bool
     jetpack_compose_security: bool
     path_traversal: bool

--- a/core/engine.py
+++ b/core/engine.py
@@ -9,6 +9,7 @@ from modules.llm_client.groq import GroqClient
 from modules.llm_client.openai import OpenAIClient
 from modules.llm_client.anthropic import AnthropicClient
 from modules.llm_client.openrouter import OpenRouterClient
+from modules.llm_client.router9 import Router9Client
 from core.call_graph import CallGraphBuilder
 from core.manifest_parser import ManifestParser
 import os
@@ -19,10 +20,49 @@ import shutil
 from rich.progress import track
 from core.logger import console
 
+# Rules evaluated ONLY against AndroidManifest.xml (in analyze_manifest), never against
+# code files in the deep scan. Single source of truth so the two paths can't drift —
+# a missing entry here previously let `strandhogg` leak into the code deep-scan and
+# false-positive on every risky Java file.
+MANIFEST_RULES = ["webview_deeplink", "intent_spoofing", "exported_components", "deeplink_hijack", "strandhogg"]
+
+# Rules that have their OWN dedicated analysis pass and must NEVER run in the generic code
+# deep-scan (analyze_file) — otherwise they leak and false-positive on .java files.
+# Manifest rules run in analyze_manifest; hardcoded_secrets_xml runs in analyze_strings_xml.
+DEDICATED_PASS_RULES = set(MANIFEST_RULES) | {"hardcoded_secrets_xml"}
+
+# [#E report-dedup] Rules that detect the same underlying issue share a "family". On the
+# same file, findings in one family collapse into a single entry; the rest move under
+# 'also_detected_by' (never deleted). Rules not listed are their own singleton family.
+VULN_FAMILIES = {
+    "webview_xss": "webview", "insecure_webview": "webview",
+    "webview_file_access": "webview", "webview_deeplink": "webview",
+    "insecure_storage": "storage", "insecure_file_permissions": "storage",
+    "exported_components": "ipc", "intent_spoofing": "ipc",
+    "deeplink_hijack": "deeplink", "deeplink_logic_bypass": "deeplink",
+}
+# Broad conceptual rule(s): on a file that already has a specific finding, these are folded
+# into it (kept under 'also_detected_by') so they don't flood the report. If a generic rule
+# is the ONLY finding on a file, it stays as a standalone finding.
+GENERIC_RULES = {"universal_logic_flaw"}
+_SEVERITY_ORDER = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
+
+# [#C] Appended to every RULE prompt (deep-scan + manifest + strings) as the LAST instruction,
+# so it overrides any prose-inviting wording inside a rule ("explain...", "say Safe"). Reduces
+# parse failures across providers. Brace-free (vuln_prompt is passed through str.format()).
+JSON_ONLY_SUFFIX = (
+    "\n\n### RESPONSE FORMAT (STRICT)\n"
+    "Return ONLY the single JSON object defined in the system prompt. "
+    "No markdown, no code fences, no commentary, and no standalone words such as "
+    "'Safe', 'VULNERABLE', 'Yes' or 'No' outside the JSON. "
+    "Put the explanation in the description field, the exploit walkthrough in attack_scenario, "
+    "and the remediation in recommendation."
+)
+
 class Engine:
     def __init__(self, settings: Settings):
         self.settings = settings
-        self.llm_client = self._setup_llm_client()
+        self._setup_llm_client()  # sets self.llm_client and self.exploit_llm_client
         self.summaries = {}
         self.masvs_mapping = self._load_masvs_mapping()
         
@@ -53,27 +93,69 @@ class Engine:
         return result_dict
 
     def _setup_llm_client(self):
-        provider = self.settings.llm.provider
+        """Builds `self.llm_client` (scanning/analysis) and `self.exploit_llm_client`
+        (PoC generation). The two are the SAME object unless `llm.exploit_provider` or
+        `llm.exploit_model` is set AND exploit generation is actually requested — some
+        models refuse or silently return empty output for exploit/PoC generation while
+        being fine for vulnerability analysis (see Updatev1.3.0.md). Building the
+        exploit-specific client is skipped entirely when exploit generation is off, so a
+        typo'd `exploit_provider` never breaks a normal scan."""
+        if self.settings.analysis.use_cache:
+            log.info("Response cache: ENABLED 💾")
+
+        self.llm_client = self._build_llm_client(self.settings.llm.provider)
+        self.exploit_llm_client = self.llm_client
+
+        exploit_provider = self.settings.llm.exploit_provider
+        exploit_model = self.settings.llm.exploit_model
+        if self.settings.analysis.generate_exploit and (exploit_provider or exploit_model):
+            effective_provider = exploit_provider or self.settings.llm.provider
+            try:
+                self.exploit_llm_client = self._build_llm_client(effective_provider, model_override=exploit_model)
+                log.info(
+                    f"Exploit generation routed to provider '{effective_provider}'"
+                    + (f" (model override: {exploit_model})" if exploit_model else "")
+                )
+            except Exception as e:
+                log.warning(
+                    f"Failed to set up exploit_provider '{effective_provider}' ({e}); "
+                    "falling back to the main provider/model for exploit generation."
+                )
+                self.exploit_llm_client = self.llm_client
+
+    def _build_llm_client(self, provider: str, model_override: str = None):
+        """Builds a cached client for `provider`. `model_override` lets a secondary use
+        (exploit generation) pick a different model on that same provider than the one
+        used for scanning/analysis; when None, that provider's own default model field
+        is used (unchanged behavior)."""
         max_tokens = self.settings.llm.max_tokens  # [#6] Configurable output limit
 
         if provider == "ollama":
-            model = self.settings.llm.model
+            model = model_override or self.settings.llm.model
             raw_client = OllamaClient(model=model, url=self.settings.llm.ollama_url, max_tokens=max_tokens)
         elif provider == "gemini":
-            model = self.settings.llm.gemini_model
+            model = model_override or self.settings.llm.gemini_model
             raw_client = GeminiClient(model=model, api_key=self.settings.llm.gemini_api_key, max_tokens=max_tokens)
         elif provider == "groq":
-            model = self.settings.llm.groq_model
+            model = model_override or self.settings.llm.groq_model
             raw_client = GroqClient(model=model, api_key=self.settings.llm.groq_api_key, max_tokens=max_tokens)
         elif provider == "openai":
-            model = self.settings.llm.openai_model
+            model = model_override or self.settings.llm.openai_model
             raw_client = OpenAIClient(model=model, api_key=self.settings.llm.openai_api_key, max_tokens=max_tokens)
         elif provider == "anthropic":
-            model = self.settings.llm.anthropic_model
+            model = model_override or self.settings.llm.anthropic_model
             raw_client = AnthropicClient(model=model, api_key=self.settings.llm.anthropic_api_key, max_tokens=max_tokens)
         elif provider == "openrouter":
-            model = self.settings.llm.openrouter_model
+            model = model_override or self.settings.llm.openrouter_model
             raw_client = OpenRouterClient(model=model, api_key=self.settings.llm.openrouter_api_key, max_tokens=max_tokens)
+        elif provider == "router9":
+            model = model_override or self.settings.llm.router9_model
+            raw_client = Router9Client(
+                model=model,
+                api_key=self.settings.llm.router9_api_key,
+                base_url=self.settings.llm.router9_base_url,
+                max_tokens=max_tokens,
+            )
         else:
             raise ValueError(f"Unsupported LLM provider: {provider}")
 
@@ -81,8 +163,6 @@ class Engine:
         # so mixing providers/models never collides.
         from core.llm_cache import CachedLLMClient
         cache_dir = "output/.dlh_cache"
-        if self.settings.analysis.use_cache:
-            log.info("Response cache: ENABLED 💾")
         return CachedLLMClient(raw_client, cache_dir, model=model, enabled=self.settings.analysis.use_cache)
 
     def get_status(self, result: dict) -> str:
@@ -166,6 +246,7 @@ class Engine:
                          "This file/rule was NOT verified — treat as unanalyzed, not clean.")
         return {
             "file": file_path,
+            "rule": rule_name,
             "vulnerability": vuln_name,
             "status": "Error",
             "result": {
@@ -175,6 +256,69 @@ class Engine:
                 "description": "Analysis could not be completed for this rule.",
             },
         }
+
+    def _dedupe_findings(self, results: list) -> list:
+        """
+        [#E] Collapse overlapping 'Vulnerable' findings on the same file so the report isn't
+        noisy. Two mechanisms, both INFORMATION-PRESERVING (merged findings are kept under
+        'also_detected_by', never dropped):
+          1. Family merge  — findings whose rules share a VULN_FAMILIES family (e.g. the
+             WebView trio) on the same file collapse into the highest-severity one.
+          2. Generic fold  — a GENERIC_RULES finding (universal_logic_flaw) on a file that
+             also has a specific finding is folded into that finding; if it is the only
+             finding on the file, it stays standalone.
+        Non-'Vulnerable' entries (Not Vulnerable / Error) pass through untouched.
+        """
+        from collections import defaultdict
+
+        def sev(r):
+            return _SEVERITY_ORDER.get(str((r.get("result") or {}).get("severity", "")).lower(), 0)
+
+        def brief(r):
+            res = r.get("result") or {}
+            return {
+                "rule": r.get("rule"),
+                "vulnerability": r.get("vulnerability"),
+                "severity": res.get("severity"),
+                "description": res.get("description"),
+            }
+
+        vulnerable = [r for r in results if str(r.get("status", "")).lower() == "vulnerable"]
+        passthrough = [r for r in results if str(r.get("status", "")).lower() != "vulnerable"]
+
+        by_file = defaultdict(list)
+        for r in vulnerable:
+            by_file[r.get("file")].append(r)
+
+        deduped = []
+        for _file, group in by_file.items():
+            # (1) family merge
+            fam_groups = defaultdict(list)
+            for r in group:
+                rule = r.get("rule") or r.get("vulnerability")
+                fam_groups[VULN_FAMILIES.get(rule, f"__self__:{rule}")].append(r)
+            merged = []
+            for _fam, items in fam_groups.items():
+                if len(items) == 1:
+                    merged.append(items[0])
+                    continue
+                primary = max(items, key=sev)
+                primary.setdefault("also_detected_by", [])
+                primary["also_detected_by"].extend(brief(o) for o in items if o is not primary)
+                merged.append(primary)
+
+            # (2) generic fold
+            generic = [m for m in merged if m.get("rule") in GENERIC_RULES]
+            specific = [m for m in merged if m.get("rule") not in GENERIC_RULES]
+            if generic and specific:
+                host = max(specific, key=sev)
+                host.setdefault("also_detected_by", [])
+                host["also_detected_by"].extend(brief(g) for g in generic)
+                deduped.extend(specific)
+            else:
+                deduped.extend(merged)
+
+        return passthrough + deduped
 
     def _find_manifest_path(self, start_path: str) -> str:
         """Traverses up the directory tree to find AndroidManifest.xml."""
@@ -271,6 +415,47 @@ class Engine:
         # If no package name extracted and not blocked, allow it.
         return True
 
+    def _detect_poc_extension(self, poc_content: str) -> str:
+        """Picks the file extension for a generated PoC/verification script.
+
+        The FIRST LINE is authoritative when it matches what `exploit_prompt.txt`
+        instructs the model to emit there (a shebang for Bash/Python; an opening
+        token for Frida JS/HTML) — checked BEFORE any whole-content substring scan.
+
+        Why: a Bash script may legitimately EMBED another language, e.g. a
+        `python3 - << 'EOF' ... EOF` heredoc, because Bash can't easily do things
+        like background logcat monitoring on its own. That embedded block contains
+        "import "/"def " just like standalone Python would. Scanning the WHOLE
+        content for those substrings (the old approach) misclassified such a script
+        as ".py" even though it starts with `#!/bin/bash` and is a single, valid,
+        directly-executable Bash script — the heredoc is an implementation detail,
+        not a second top-level script. The first line is what actually determines
+        how the file executes (the OS reads the shebang), so it must win.
+        """
+        first_line = poc_content.split("\n", 1)[0].strip()
+
+        if first_line.startswith("#!"):
+            if "python" in first_line:
+                return ".py"
+            if "bash" in first_line or first_line.endswith("sh"):
+                return ".sh"
+        elif first_line.startswith("Java.perform(") or first_line.startswith("setTimeout("):
+            return ".js"
+        elif first_line.lower().startswith(("<!doctype", "<html")):
+            return ".html"
+
+        # No (recognized) first-line signal -> fall back to content sniffing, for the
+        # rare case the model doesn't follow the "start with X" instruction.
+        if "Java.perform(" in poc_content or "Java.use(" in poc_content or "console.log(" in poc_content:
+            return ".js"
+        if "<html" in poc_content.lower() or "<script" in poc_content.lower() or "<!doctype" in poc_content.lower():
+            return ".html"
+        if "import " in poc_content or "def " in poc_content:
+            return ".py"
+        if "#!/bin/bash" in poc_content or "#!/bin/sh" in poc_content or "adb shell" in poc_content:
+            return ".sh"
+        return ".txt"
+
     def _generate_poc(self, file_path: str, code_snippet: str, vuln_description: str, rule_name: str, global_context: str = ""):
         """Generates a PoC script for a confirmed vulnerability."""
         try:
@@ -347,7 +532,7 @@ class Engine:
                 "file_path": file_path
             }
             
-            poc_content = self.llm_client.analyze_code("", context_wrapper_safe)
+            poc_content = self.exploit_llm_client.analyze_code("", context_wrapper_safe)
             
             if not poc_content:
                 log.warning("PoC generation returned empty.")
@@ -368,19 +553,8 @@ class Engine:
                 poc_content = _re.sub(r'\n?```\s*$', '', poc_content.strip())
                 poc_content = poc_content.strip()
 
-            # Determine extension based on cleaned content
-            ext = ".txt"
-            if "Java.perform" in poc_content or "Java.use" in poc_content or "console.log" in poc_content:
-                ext = ".js"
-            elif "#!/usr/bin/env python" in poc_content or ("import " in poc_content and "def " in poc_content):
-                ext = ".py"
-            elif "import " in poc_content or "def " in poc_content:
-                ext = ".py" 
-            elif "<html" in poc_content.lower() or "<script" in poc_content.lower() or "<!doctype" in poc_content.lower():
-                ext = ".html"
-            elif "#!/bin/bash" in poc_content or "#!/bin/sh" in poc_content or "adb shell" in poc_content:
-                ext = ".sh"
-            
+            ext = self._detect_poc_extension(poc_content)
+
             # Use the pre-calculated exploit directory from 'run' if available, otherwise fallback
             if hasattr(self, 'final_exploit_dir') and self.final_exploit_dir:
                  exploit_dir = self.final_exploit_dir
@@ -513,6 +687,50 @@ class Engine:
                 "false_positive_analysis": "Parsing failed."
             }
 
+    def _file_to_class_dotted(self, file_path: str):
+        """Best-effort fully-qualified (dotted) class name from a decompiled file path,
+        used to look up the component's AndroidManifest entry. Handles JADX (`.../sources/`)
+        and apktool (`.../smali/` or `.../smali_classesN/`) layouts."""
+        import re
+        p = str(file_path).replace("\\", "/")
+        rel = None
+        if "/sources/" in p:
+            rel = p.split("/sources/", 1)[1]
+        else:
+            m = re.search(r"/smali(?:_classes\d+)?/", p)
+            if m:
+                rel = p[m.end():]
+        if not rel:
+            return None
+        for ext in (".java", ".smali"):
+            if rel.endswith(ext):
+                rel = rel[: -len(ext)]
+                break
+        return rel.replace("/", ".") if rel else None
+
+    def _manifest_context_for(self, file_path: str) -> str:
+        """[B] Inject the component's AndroidManifest entry (exported status, permission,
+        intent-filters) into the LLM input so IPC/exported-dependent rules (intent_redirection,
+        pending_intent_hijacking, fragment_injection, …) do not have to GUESS reachability.
+        The parsing already exists in ManifestParser.get_component_details()."""
+        parser = getattr(self, "manifest_parser", None)
+        if parser is None:
+            return ""
+        cls = self._file_to_class_dotted(file_path)
+        if not cls:
+            return ""
+        try:
+            details = parser.get_component_details(cls)
+        except Exception:
+            return ""
+        if not details or not details.get("context_str"):
+            return ""
+        return (
+            "\n\n### COMPONENT CONTEXT (from AndroidManifest.xml)\n"
+            "Authoritative reachability facts for this class — use them, do NOT guess the exported status:\n"
+            + details["context_str"]
+        )
+
     def analyze_file(self, file_path, rules_to_run: list = None):
         results = []
         with open(file_path, "r", encoding="utf-8") as f:
@@ -559,6 +777,11 @@ class Engine:
         # [#5] Cap oversized content before it reaches the LLM.
         full_code_context = self._truncate_for_llm(full_code_context)
 
+        # [B] Reachability context from the manifest. Kept OUT of `full_code_context` so it
+        # doesn't affect per-rule pattern gating; appended only to what the LLM actually sees
+        # (it's small, so it survives after truncation).
+        llm_input = full_code_context + self._manifest_context_for(file_path)
+
         # [V1.1.7 Library Hunter - Exclusive Mode]
         # Logic: If this is a 3rd party library file, we run ONLY the specialized audit prompt.
         # This saves tokens by not running the 20+ standard rules on generic library code.
@@ -598,14 +821,14 @@ class Engine:
                  
                  context = {
                     "system_prompt": system_prompt,
-                    "vuln_prompt": prompt_data["prompt"],
+                    "vuln_prompt": prompt_data["prompt"] + JSON_ONLY_SUFFIX,
                     "file_path": file_path,
                     "expect_json": True  # [A] Rule analysis requires JSON output
                  }
 
                  # Run Analysis
                  try:
-                     raw_result = self.llm_client.analyze_code(full_code_context, context)
+                     raw_result = self.llm_client.analyze_code(llm_input, context)
 
                      # [FIX #2] A failed LLM call must not read as a clean library.
                      if self._is_failed_response(raw_result):
@@ -635,6 +858,7 @@ class Engine:
 
                          results.append({
                             "file": file_path,
+                            "rule": "library_vulnerability",
                             "vulnerability": "Library Hunter",
                             "status": status,
                             "result": parsed_result
@@ -648,7 +872,7 @@ class Engine:
              return results
 
         for rule_name, enabled in self.settings.rules.model_dump().items():
-            if enabled and rule_name not in ["webview_deeplink", "intent_spoofing", "exported_components", "deeplink_hijack"]:
+            if enabled and rule_name not in DEDICATED_PASS_RULES:
                 if rules_to_run and rule_name not in rules_to_run:
                     continue
                 prompt_path = f"config/prompts/vuln_rules/{rule_name}.yaml"
@@ -676,24 +900,19 @@ class Engine:
                     system_prompt += f"Standard: \"{masvs_desc}\"\n"
                     system_prompt += f"Ensure your verification aligns strictly with this standard."
 
-                # --- DYNAMIC PROMPT ADAPTATION (Language Agnostic) ---
+                # [A] Rule prompts are language-agnostic ("Java or Smali"), so the old
+                # vuln_prompt.replace("smali","java") hack has been retired.
                 vuln_prompt = prompt_data["prompt"]
-                if file_path.endswith(".java"):
-                    # Improve prompt context by switching terminology
-                    # "Analyze this smali code..." -> "Analyze this java code..."
-                    # ```smali -> ```java
-                    vuln_prompt = vuln_prompt.replace("smali", "java")
-                    vuln_prompt = vuln_prompt.replace("Smali", "Java")
 
                 context = {
                     "system_prompt": system_prompt,
-                    "vuln_prompt": vuln_prompt,
+                    "vuln_prompt": vuln_prompt + JSON_ONLY_SUFFIX,
                     "file_path": file_path,
                     "expect_json": True  # [A] Rule analysis requires JSON output
                 }
 
-                # Pass the ENRICHED context
-                raw_result = self.llm_client.analyze_code(full_code_context, context)
+                # Pass the ENRICHED context (code + cross-ref + manifest reachability)
+                raw_result = self.llm_client.analyze_code(llm_input, context)
 
                 # [FIX #2] Distinguish a failed LLM call from a genuine "clean" verdict.
                 if self._is_failed_response(raw_result):
@@ -726,6 +945,7 @@ class Engine:
 
                 results.append({
                     "file": file_path,
+                    "rule": rule_name,
                     "vulnerability": prompt_data["name"],
                     "status": status,
                     "result": parsed_result # Store the full structured object
@@ -737,8 +957,7 @@ class Engine:
         with open(manifest_path, "r", encoding="utf-8") as f:
             code_snippet = f.read()
 
-        manifest_rules = ["webview_deeplink", "intent_spoofing", "exported_components", "deeplink_hijack", "strandhogg"]
-        for rule_name in manifest_rules:
+        for rule_name in MANIFEST_RULES:
             if getattr(self.settings.rules, rule_name):
                 if rules_to_run and rule_name not in rules_to_run:
                     continue
@@ -748,7 +967,7 @@ class Engine:
 
                 context = {
                     "system_prompt": self._load_system_prompt(),
-                    "vuln_prompt": prompt_data["prompt"],
+                    "vuln_prompt": prompt_data["prompt"] + JSON_ONLY_SUFFIX,
                     "file_path": manifest_path,
                     "expect_json": True  # [A] Rule analysis requires JSON output
                 }
@@ -785,9 +1004,10 @@ class Engine:
 
                 results.append({
                     "file": manifest_path,
+                    "rule": rule_name,
                     "vulnerability": prompt_data["name"],
                     "status": status,
-                    "result": parsed_result 
+                    "result": parsed_result
                 })
         return results
 
@@ -830,7 +1050,7 @@ class Engine:
 
         context = {
             "system_prompt": self._load_system_prompt(),
-            "vuln_prompt": prompt_data["prompt"],
+            "vuln_prompt": prompt_data["prompt"] + JSON_ONLY_SUFFIX,
             "file_path": strings_path,
             "expect_json": True  # [A] Rule analysis requires JSON output
         }
@@ -863,9 +1083,10 @@ class Engine:
 
         results.append({
             "file": strings_path,
+            "rule": rule_name,
             "vulnerability": prompt_data["name"],
             "status": status,
-            "result": parsed_result 
+            "result": parsed_result
         })
         return results
 
@@ -939,6 +1160,39 @@ class Engine:
         log.success(f"Identified {len(risky_files)} risky files.")
         return risky_files
 
+    def _pattern_matched_files(self, files: list, patterns: list, app_package_name: str = "") -> list:
+        """First-party files whose content matches an enabled rule's detection_pattern.
+
+        A static pattern hit is a STRONG signal, so these files must reach the deep-scan
+        (where per-rule gating + the rule LLM decide the verdict) and must NOT be dropped
+        by the coarse LLM risk-triage. Layer-2 bug this fixes: ZipSlipActivity matched the
+        zip_slip pattern yet identify_risky_chunks judged it "not risky" and dropped it
+        before any rule ran. Scoped to the app package so the added deep-scan cost stays
+        bounded to first-party code (library files still go through the normal triage).
+        """
+        import re
+        compiled = []
+        for p in patterns:
+            try:
+                compiled.append(re.compile(p, re.IGNORECASE | re.DOTALL))
+            except re.error:
+                continue
+        if not compiled:
+            return []
+        pkg_frag = app_package_name.replace(".", os.sep) if app_package_name else None
+        hits = []
+        for f in files:
+            if pkg_frag and pkg_frag not in f:
+                continue  # only rescue first-party files from the risk-triage
+            try:
+                with open(f, "r", encoding="utf-8", errors="ignore") as fh:
+                    content = fh.read()
+            except OSError:
+                continue
+            if any(rx.search(content) for rx in compiled):
+                hits.append(f)
+        return hits
+
     def summarize_app(self, manifest_path: str, summaries: dict):
         log.info("Summarizing application capabilities...")
         
@@ -962,26 +1216,42 @@ class Engine:
         return app_summary
 
     def generate_attack_surface_map(self, manifest_path: str, summaries: dict):
+        """[v1.3.0] Returns a compact, structured INVENTORY dict (exported components,
+        deep links, network/IPC/file-io/deserialization/reflection signals, manifest
+        flags) — not a narrative report. A downstream tool (e.g. an HTML report) is
+        expected to render this into bullets/tables itself. Kept small on purpose:
+        the per-file vulnerability findings already carry the detailed explanations."""
         log.info("Generating attack surface map...")
-        
+
         with open(manifest_path, "r", encoding="utf-8") as f:
             manifest = f.read()
-            
+
         summaries_text = "\n".join(f"- {file_path}: {summary}" for file_path, summary in summaries.items())
-        
+
         prompt = self._load_attack_surface_prompt().format(manifest=manifest, summaries=summaries_text)
         # Escape curly braces to prevent double formatting issues in analyze_code
         prompt = prompt.replace("{", "{{").replace("}", "}}")
-        
+
         context = {
             "system_prompt": "",
             "vuln_prompt": prompt,
-            "file_path": manifest_path
+            "file_path": manifest_path,
+            "expect_json": True  # force JSON mode on providers that support it (e.g. Ollama)
         }
-        
-        attack_surface_map = self.llm_client.analyze_code("", context)
+
+        raw_result = self.llm_client.analyze_code("", context)
+
+        if self._is_failed_response(raw_result):
+            log.warning("Attack surface map generation failed (empty LLM response).")
+            return {"error": "LLM call failed (empty response)"}
+
+        parsed = self._parse_llm_response(raw_result)
+        if parsed.get("_parse_failed"):
+            log.warning("Attack surface map response was not valid JSON.")
+            return {"error": "Unparseable LLM output", "raw": raw_result[:500]}
+
         log.success("Attack surface map generated.")
-        return attack_surface_map
+        return parsed
 
     def _find_smali_fallback(self, java_path: str, output_dir: str) -> str:
         """Helper to find corresponding smali file for a java file."""
@@ -1102,7 +1372,7 @@ class Engine:
             self.call_graph_builder = None
 
         smali_rules_enabled = any(
-            enabled and rule_name not in ["webview_deeplink", "intent_spoofing", "exported_components", "deeplink_hijack"]
+            enabled and rule_name not in DEDICATED_PASS_RULES
             for rule_name, enabled in self.settings.rules.model_dump().items()
         )
 
@@ -1117,7 +1387,7 @@ class Engine:
             extra_keywords = []
             extra_regex = [] # [V1.2] Regex Support
             for rule_name, enabled in self.settings.rules.model_dump().items():
-                if enabled and rule_name not in ["webview_deeplink", "intent_spoofing", "exported_components", "deeplink_hijack", "strandhogg"]:
+                if enabled and rule_name not in DEDICATED_PASS_RULES:
                      try:
                         prompt_path = f"config/prompts/vuln_rules/{rule_name}.yaml"
                         with open(prompt_path, "r") as f:
@@ -1152,6 +1422,7 @@ class Engine:
                 try:
                     parser = ManifestParser(manifest_path)
                     app_package_name = parser.package_name
+                    self.manifest_parser = parser  # [B] reused by analyze_file for reachability context
                     log.info(f"Identified App Package: {app_package_name}")
                 except Exception as e:
                     log.warning(f"Failed to parse package name: {e}")
@@ -1286,11 +1557,23 @@ class Engine:
                  target_files = final_targets_for_summary
                  # No summarization logic for pure static, just pass to analyze
                  
-            elif filter_mode == "hybrid": 
+            elif filter_mode == "hybrid":
                 # Static found targets -> Summarize them -> Ask LLM
                 if final_targets_for_summary:
                     self.summaries = self.summarize_chunks(output_dir, file_list=final_targets_for_summary)
-                    target_files = self.identify_risky_chunks(self.summaries)
+                    llm_risky = self.identify_risky_chunks(self.summaries)
+                    # A first-party file that matches a rule's detection_pattern is a strong
+                    # static signal; deep-scan it even if the LLM risk-triage said "no" (it
+                    # dropped a real hit — ZipSlipActivity — before any rule could run).
+                    pattern_risky = self._pattern_matched_files(
+                        final_targets_for_summary, extra_regex, app_package_name
+                    )
+                    target_files = list(dict.fromkeys(llm_risky + pattern_risky))
+                    log.info(
+                        f"Deep-scan targets: {len(llm_risky)} via risk-triage + "
+                        f"{len(pattern_risky)} first-party static-pattern hits = "
+                        f"{len(target_files)} unique."
+                    )
                 else:
                     target_files = []
 
@@ -1340,6 +1623,9 @@ class Engine:
                     except Exception as exc:
                         log.error(f"{file_path} generated an exception: {exc}")
 
+        # [#E] Collapse overlapping same-file findings (info-preserving via 'also_detected_by').
+        all_results = self._dedupe_findings(all_results)
+
         final_report = {
             "app_summary": app_summary,
             "attack_surface_map": attack_surface_map,
@@ -1367,11 +1653,18 @@ class Engine:
                 f"See 'analysis_errors' in the report."
             )
 
-        # [#4] Report cache effectiveness.
+        # [#4] Report cache effectiveness. Merge in exploit_llm_client's own stats when it's
+        # a separate client (different exploit_provider/exploit_model) so the count is complete.
         if hasattr(self.llm_client, "cache_stats"):
             stats = self.llm_client.cache_stats()
-            if stats.get("enabled"):
-                log.info(f"Response cache: {stats['hits']} hit(s), {stats['misses']} miss(es).")
+            hits, misses, enabled = stats.get("hits", 0), stats.get("misses", 0), stats.get("enabled")
+            if self.exploit_llm_client is not self.llm_client and hasattr(self.exploit_llm_client, "cache_stats"):
+                exploit_stats = self.exploit_llm_client.cache_stats()
+                hits += exploit_stats.get("hits", 0)
+                misses += exploit_stats.get("misses", 0)
+                enabled = enabled or exploit_stats.get("enabled")
+            if enabled:
+                log.info(f"Response cache: {hits} hit(s), {misses} miss(es).")
 
     def _load_system_prompt(self) -> str:
         with open("config/prompts/system_prompt.txt", "r") as f:

--- a/core/manifest_parser.py
+++ b/core/manifest_parser.py
@@ -6,7 +6,7 @@ class ManifestParser:
     def __init__(self, manifest_path: str):
         self.manifest_path = manifest_path
         self.root = self._parse_manifest()
-        self.package_name = self.root.get('package') if self.root else ""
+        self.package_name = self.root.get('package') if self.root is not None else ""
 
     def _parse_manifest(self):
         """Parses the XML file safely."""
@@ -26,7 +26,7 @@ class ManifestParser:
         and returns its details: Intent Filters, Permissions, Exported status.
         Handles partial names (e.g. '.MainActivity') and full names.
         """
-        if not self.root:
+        if self.root is None:
             return {}
 
         # Normalize component name (e.g. "com.example.MainActivity" -> ".MainActivity" suffix check)
@@ -67,13 +67,17 @@ class ManifestParser:
                      # Weak match, keep looking for stronger match but store this
                      current_best_match = node
 
-            if target_node:
+            # NOTE: an ElementTree Element with no children is falsy, so a component
+            # declared without child nodes (e.g. an <activity .../> with no intent-filter)
+            # must be compared with `is not None`, not truthiness — otherwise it reads as
+            # "not found" and this method wrongly returns {}.
+            if target_node is not None:
                 break
-        
-        if not target_node and current_best_match:
+
+        if target_node is None and current_best_match is not None:
             target_node = current_best_match
 
-        if not target_node:
+        if target_node is None:
             return {}
 
         # Extract Details

--- a/dlh.py
+++ b/dlh.py
@@ -165,6 +165,7 @@ def set_model(model: str = typer.Argument(None, help="The LLM model to use.")):
         "openai": "openai_model",
         "anthropic": "anthropic_model",
         "openrouter": "openrouter_model",
+        "router9": "router9_model",
     }
     
     if model is None:
@@ -390,7 +391,7 @@ def config_wizard():
     
     print("Welcome to the Droid LLM Hunter configuration wizard!")
     
-    provider = typer.prompt("Select LLM provider (ollama, gemini, groq, openai, anthropic, openrouter)")
+    provider = typer.prompt("Select LLM provider (ollama, gemini, groq, openai, anthropic, openrouter, router9)")
     
     if provider == "ollama":
         model = typer.prompt("Enter Ollama model name")
@@ -452,8 +453,23 @@ def config_wizard():
                 "openrouter_api_key": openrouter_api_key
             }
         }
+    elif provider == "router9":
+        router9_model = typer.prompt("Enter 9Router model name (e.g. gc/gemini-2.5-pro)")
+        router9_api_key = typer.prompt("Enter 9Router API key")
+        router9_base_url = typer.prompt(
+            "Enter 9Router base URL",
+            default="http://localhost:20128/v1/chat/completions"
+        )
+        settings = {
+            "llm": {
+                "provider": provider,
+                "router9_model": router9_model,
+                "router9_api_key": router9_api_key,
+                "router9_base_url": router9_base_url
+            }
+        }
     else:
-        print(f"Invalid provider '{provider}'. Choose from: ollama, gemini, groq, openai, anthropic, openrouter")
+        print(f"Invalid provider '{provider}'. Choose from: ollama, gemini, groq, openai, anthropic, openrouter, router9")
         raise typer.Exit()
 
     try:

--- a/document/ARCHITECTURE_EXPLANATION.md
+++ b/document/ARCHITECTURE_EXPLANATION.md
@@ -29,7 +29,7 @@ This acts as a "Coarse Sieve" running **locally** using **Regex (Regular Express
 *   **Cost:** FREE (0 Tokens).
 *   **Speed:** Blazing Fast (< 1 second).
 *   **Examples:**
-    *   **PendingIntent:** Doesn't just find `PendingIntent`, but looks for the pattern: `PendingIntent` + (`getActivity` OR `getService`) + `FLAG_MUTABLE`.
+    *   **PendingIntent:** Doesn't just find `PendingIntent`, but looks for the pattern: `PendingIntent` + (`getActivity` OR `getService`) + `FLAG_MUTABLE` (or its decompiled integer value `33554432`, since JADX inlines the constant).
     *   **ZipSlip:** Doesn't just find `ZipEntry`, but looks for `ZipEntry` + `.getName`.
 
 If the specific regex pattern is **NOT** found, the file is immediately discarded. The LLM is never invoked.
@@ -42,6 +42,12 @@ This acts as the "Judge", analyzing only the files that survived Stage 1.
 *   **Example:**
     *   *Engine* flags a file for ZipSlip pattern.
     *   *LLM* is asked: "I see `ZipEntry.getName` here. Is there a `getCanonicalPath` check preceding it?"
+
+### Stage 2.5: "Recall Safeguard" — static hits are never silently dropped
+
+In `hybrid` mode a lightweight LLM **risk-triage** (`identify_risk_prompt.txt`) reads each file's *summary* and votes *risky / not risky* before the deep scan, to save tokens. Because that vote is a coarse LLM judgment, it can occasionally drop a genuinely vulnerable file. To protect recall, **any first-party file whose content matches an enabled rule's `detection_pattern` is deep-scanned regardless of the triage vote** (`Engine._pattern_matched_files`). A static pattern hit is a strong signal, so it must reach rule gating + the rule LLM — it is never discarded by the triage. This is scoped to the app package, so library files still go through the normal triage and the added cost stays bounded to first-party code.
+
+> This safeguard was added after the Layer-2 testbed caught the triage dropping `ZipSlipActivity` even though the `zip_slip` pattern matched it.
 
 ### Stage 3: "Specialized Pipelines" (Resource Files 📄)
 Some rules target **configuration files** (XML) rather than source code. These bypass the Regex Filter and use dedicated parsers:
@@ -93,7 +99,7 @@ This turns an interrupted scan (crash, rate limit) into a **free resume** — re
     *   Vulnerability rules now support a new field: `detection_pattern`.
     *   Example from `pending_intent_hijacking.yaml`:
         ```yaml
-        detection_pattern: "PendingIntent\\.(getActivity|getService|getBroadcast).*FLAG_MUTABLE"
+        detection_pattern: "PendingIntent(?:\\.|;->)(getActivity|getService|getBroadcast).*(FLAG_MUTABLE|33554432)"
         ```
 
 ---
@@ -132,11 +138,11 @@ Once added, the Engine automatically switches to Hybrid Mode for that rule.
 
 For full transparency, it is important to understand the "Blind Spots" of this Regex-based approach. While it covers 95-99% of standard cases, some edge cases might be missed to preserve performance.
 
-### 1. Hardcoded Secrets (Naming Dependency)
-*   **Pattern:** `(?i)(api_key|password|secret|token).*=.*["']`
-*   **Strength:** Highly efficient, only flags variables that *look* like secrets.
-*   **Weakness:** If a developer uses random variable names (e.g., `String x = "AIza...";`), Regex will NOT catch it.
-*   **Trade-off:** Scanning *every* string assignment would result in millions of false positives and massive token costs. This is a necessary balance.
+### 1. Hardcoded Secrets (Entropy + Naming)
+*   **Pattern:** `(?i)(AIza…|AKIA…|const-string.*(api_key|password|secret|token)|(api_key|password|secret|token).*=.*["'])`
+*   **Strength:** Catches BOTH high-entropy key prefixes (Google `AIza…`, AWS `AKIA…`) *regardless of the variable name*, AND secret-looking variable assignments. (So `String x = "AIza…";` **is** caught via the prefix.)
+*   **Weakness:** A secret with no known prefix stored under a random variable name (e.g. `String x = "9f3c…";`) can still be missed.
+*   **Trade-off:** Flagging *every* string assignment would explode false positives and token cost. This is a necessary balance.
 
 ### 2. SQL Injection (Standard API Dependency)
 *   **Pattern:** `(rawQuery|execSQL)\\s*\\(`
@@ -144,9 +150,11 @@ For full transparency, it is important to understand the "Blind Spots" of this R
 *   **Weakness:** If using obscure 3rd-party ORMs or custom wrapper functions (e.g., `myDatabaseHelper.doQuery(...)`), it might be missed.
 *   **Trade-off:** `rawQuery` accounts for the vast majority of SQLi vulnerabilities in native Android.
 
-### 3. Insecure File Permissions (Constant Dependency)
-*   **Pattern:** `MODE_WORLD_READABLE`
-*   **Weakness:** If a developer uses the integer value (`1`) instead of the constant name, Regex won't know.
-*   **Reality Check:** Developers almost always use the IDE auto-completed constants, making this risk negligible.
+### 3. Insecure File Permissions (Constant + API Dependency)
+*   **Pattern (v1.3.0):** `MODE_WORLD_READABLE|MODE_WORLD_WRITABLE|set(Readable|Writable)\s*\(\s*true\s*,\s*false`
+*   **Improvement (v1.3.0):** now also detects `File.setReadable(true, false)` / `setWritable(true, false)` — a real-world world-accessible pattern the old `MODE_WORLD_*`-only regex missed (VulnerAppDLH used exactly this, so the earlier "negligible" assumption was wrong).
+*   **Remaining weakness:** the raw integer mode (`openFileOutput(f, 1)`) is still not flagged — matching a bare `1` would cause massive false positives. This narrow gap is accepted.
 
 **Conclusion:** The current configuration represents the "Best Practice" sweet spot. Tightening regex increases False Negatives; loosening it explodes Token Costs.
+
+> **v1.3.0 pattern refinements** (validated by the semantic Golden Test so recall did not regress): `path_traversal` now keys on the real read signal `(openFile|FileInputStream|FileOutputStream)\s*\(` instead of a bare `openFile` (which only matched by coincidence); `insecure_file_permissions` gained `setReadable/setWritable(true,false)`; and `universal_logic_flaw` was made **LLM-exclusive** (no `detection_pattern`) so per-rule gating never skips a conceptual flaw. Several method-call patterns are now dual-language (Java `.method` + Smali `;->method`).

--- a/document/ATTACK_SURFACE_MAPPER.md
+++ b/document/ATTACK_SURFACE_MAPPER.md
@@ -34,38 +34,40 @@ The engine executes the following logic pipeline:
     *   *Example Summary:* "This class handles credit card input and submits it to an API."
 
 3.  **Strategic Synthesis (LLM):**
-    *   The engine sends a prompt: *"Here is the list of open doors (Manifest). Here is what happens behind each door (Summaries). Map out the attack vectors."*
+    *   **[v1.3.0]** The engine sends a prompt asking for a compact **JSON inventory** — *not* a narrated report: *"Extract these attacker-relevant facts (exported components, deep links, network/IPC/file-io/deserialization/reflection signals, manifest flags) as a flat JSON object. No prose, no per-item impact commentary."* Per-item explanations were deliberately dropped from this feature — they duplicated what the detailed, per-file vulnerability findings already say (see [Scan Workflow](SCAN-WORKFLOW.md)). This map is a **recon-style inventory**, meant to be rendered into bullets/tables by a report layer (e.g. a dashboard), not read as prose itself.
 
 ---
 
 ## 📊 Example Output
 
-The JSON report will contain a section like this:
+**[v1.3.0]** `report["attack_surface_map"]` is a flat JSON object (engine-parsed via `Engine.generate_attack_surface_map`, not raw LLM text):
 
 ```json
-"attack_surface_map": [
-  {
-    "component": "com.example.DeepLinkHandlerActivity",
-    "type": "Activity",
-    "exposure": "Deep Link (myapp://reset-password)",
-    "description": "Handles password reset via URL parameters.",
-    "potential_attack": "The code summary indicates it reads 'token' param without validation. Attackers could craft a malicious link to reset victim passwords."
-  },
-  {
-    "component": "com.example.DataReceiver",
-    "type": "BroadcastReceiver",
-    "exposure": "Exported = True",
-    "description": "Processes incoming serialized objects.",
-    "potential_attack": "High risk of Deserialization Attack if an attacker sends a malicious Intent with a crafted parcelable."
-  }
-]
+"attack_surface_map": {
+  "exported_activities": ["MainActivity", "DeepLinkHandlerActivity"],
+  "exported_receivers": ["DataReceiver"],
+  "exported_services": [],
+  "exported_providers": [],
+  "deep_links": [
+    {"scheme": "myapp", "host": "reset-password", "handler": "DeepLinkHandlerActivity"}
+  ],
+  "unprotected_broadcasts": [],
+  "network": ["http"],
+  "file_io": false,
+  "ipc": true,
+  "deserialization": true,
+  "reflection": false,
+  "manifest_flags": {"debuggable": false, "allow_backup": true}
+}
 ```
+
+On a failed/unparseable LLM response, this field is `{"error": "..."}` instead of being silently empty or `null` — a failure is never presented as a clean/empty inventory.
 
 ## ✅ Why Use This?
 
-1.  **Prioritization:** Auditors can stop wasting time on internal utility classes and focus immediately on the "Public Interface" of the app.
-2.  **Context-Aware Risk:** A vulnerability in an *Exported* component is **Critical**. The same vulnerability in a private component is often just *Medium* or *Low*. This map highlights the Criticals.
-3.  **Red Teaming Ready:** Provides an instant checklist for penetration testing (e.g., "Try sending Intent X to Component Y").
+1.  **Prioritization:** Auditors can stop wasting time on internal utility classes and focus immediately on the "Public Interface" of the app — the `exported_*` and `deep_links` arrays name it directly.
+2.  **Context-Aware Risk:** A vulnerability in an *Exported* component is **Critical**. The same vulnerability in a private component is often just *Medium* or *Low*. Cross-reference this inventory against the per-file findings to see which vulnerable files are actually exposed.
+3.  **Red Teaming Ready:** The `deep_links` array (scheme/host/handler) and `ipc`/`file_io`/`deserialization`/`reflection` signals give an instant recon checklist — e.g. "try sending a crafted Intent to `DataReceiver`, deserialization is in play here."
 
 ## ⚙️ How to Enable
 

--- a/document/CONFIGURATION.md
+++ b/document/CONFIGURATION.md
@@ -62,6 +62,8 @@ Configure the analysis strategy to balance speed, cost, and accuracy.
 1. **Phase 1 (Static):** Find files with dangerous keywords.
 2. **Phase 2 (LLM Verification):** Only those specific files are summarized and checked by the LLM to confirm if they are truly risky.
 
+> **[v1.3.0] Recall safeguard:** first-party files whose content matches an enabled rule's `detection_pattern` are deep-scanned even if the LLM risk-triage would skip them — a strong static signal is never dropped. See [Architecture](ARCHITECTURE_EXPLANATION.md).
+
 | | |
 |--|--|
 | ✅ **Pros** | Extreme Token Savings (ignores safe files), Good Accuracy |
@@ -102,6 +104,47 @@ Droid LLM Hunter supports dual decompilation to balance reliability and analysis
 - **Result:** Best of both worlds — Analysis quality of Java with the reliability of Smali.
 
 ---
+
+## LLM Providers
+
+Supported `llm.provider` values: `ollama`, `gemini`, `groq`, `openai`, `anthropic`, `openrouter`, `router9`.
+
+### 9Router (`router9`)
+
+[9Router](https://github.com/9router/9router) is a **self-hosted, OpenAI-compatible LLM router**: one local endpoint that fans out to many providers/models via a provider-prefixed model name (e.g. `gc/gemini-2.5-pro` routes through to Gemini). Configure it like any other provider:
+
+```yaml
+llm:
+  provider: router9
+  router9_model: gc/gemini-2.5-pro
+  router9_api_key: sk-...
+  router9_base_url: http://localhost:20128/v1/chat/completions   # your self-hosted instance
+```
+
+- **`router9_base_url` is configurable** (unlike the other clients, which hit a fixed public URL) since 9Router is self-hosted — host/port vary per install.
+- **Streaming quirk:** 9Router's `/v1/chat/completions` endpoint was observed to return a **Server-Sent Events (SSE) stream** (`Content-Type: text/event-stream`, `data: {...}` chunks) even for a plain, non-streaming request. The client (`modules/llm_client/router9.py`) detects this via the response's `Content-Type` header and parses the SSE chunks accordingly, falling back to a normal single-JSON response if the router ever returns one instead.
+- **Reasoning models eat into `max_tokens`:** routing to a reasoning-capable model (e.g. `gemini-2.5-pro`) burns part of the `max_tokens` budget on hidden `reasoning_tokens` before any visible output is produced. A too-low `max_tokens` can silently truncate the answer (`finish_reason: "length"`) — this was confirmed live against a real 9Router instance during testing. If responses look cut off, raise `llm.max_tokens` (same guidance as OpenRouter's `kimi-k3`, which needs `8192`).
+
+### Routing `--generate-exploit` to a different provider (`exploit_provider` / `exploit_model`)
+
+Some models happily analyze code for vulnerabilities but refuse — or silently return empty output — when asked to write a working PoC/verification script, even with authorized-assessment framing in `exploit_prompt.txt`. This was confirmed live: a reasoning model routed through `router9` returned nothing for `intent_redirection`, while Anthropic's `claude-opus-4-6` produced a complete script for the identical finding.
+
+Rather than switching your whole `provider` just for exploit generation, point ONLY that stage at a different (known-permissive) provider/model:
+
+```yaml
+llm:
+  provider: router9              # used for scanning/analysis (summarize, risk-ID, rule verification, ...)
+  router9_model: jem/glm-5.2
+  anthropic_api_key: sk-ant-...   # already present for the `anthropic` provider — reused below, no duplication
+  anthropic_model: claude-opus-4-6
+  exploit_provider: anthropic     # --generate-exploit only: use Anthropic instead of router9
+  # exploit_model: claude-sonnet-4-5-20250929   # optional: override the model on exploit_provider (or on `provider`, if exploit_provider is unset)
+```
+
+- **Both fields are optional and independent.** `exploit_provider` alone switches provider (using that provider's own default model). `exploit_model` alone keeps the same provider but overrides just the model. Neither set → exploit generation uses the main `provider`/model, unchanged from before this feature existed.
+- **No separate API key field** — `exploit_provider: anthropic` reuses `anthropic_api_key`/`anthropic_model` already in this file; there's no `exploit_api_key`.
+- **Safe by design:** the exploit-specific client is only built when `--generate-exploit` is actually requested, so a typo'd `exploit_provider` never breaks a normal scan. If building it fails for any reason, DLH logs a warning and falls back to the main provider/model rather than crashing the whole run.
+- **Cache-friendly:** the response cache is keyed by model, so exploit-gen calls and scan calls never collide even when routed to different providers; the end-of-run `Response cache: N hit(s), M miss(es)` line reports the combined total.
 
 ## JADX Path Configuration
 

--- a/document/EXPLOIT_GENERATOR.md
+++ b/document/EXPLOIT_GENERATOR.md
@@ -29,7 +29,7 @@ Droid LLM Hunter generates **ready-to-execute** exploit scripts for every confir
 
 ---
 
-## 🧠 Core Features (New in v1.1.3)
+## 🧠 Core Features
 
 ### 1. Smart Scope Filtering (The "Immune System") 
 *   **Problem**: Engines often waste time scanning irrelevant library files (e.g., `androidx`, `r0.java`) which leads to hallucinations and broken exploits.
@@ -48,15 +48,22 @@ Droid LLM Hunter generates **ready-to-execute** exploit scripts for every confir
     *   **Phase 3 (Execution)**: The Engine revisits the findings and generates chained exploits.
 *   **Result**: The AI can write an exploit for File B that *uses* the token found in File A. It connects the dots.
 
-### 3. Manifest-Aware Payload Injection �️
+### 3. Manifest-Aware Payload Injection 🗺️
 *   **Problem**: AI models hallucinate Intent actions and Deep Link URLs.
 *   **Solution**: The engine parses `AndroidManifest.xml`, extracts the **exact** Intent Filters, and injects this context into the prompt.
 *   **Result**: Generated exploits use the **correct URL** guaranteed.
+*   **[v1.3.0 fix]** `ManifestParser.get_component_details()` used to return `{}` ("component not found") for any component declared **without** an `<intent-filter>` — a childless XML element is falsy in Python, and the old code checked `if target_node:` instead of `if target_node is not None:`. Exploits for components with no intent-filter (a plain exported Activity, say) were silently missing this manifest context. Fixed — manifest injection now works for every exported component, not just ones with intent-filters.
 
 ### 4. Hardcoded Secrets "Auto-Fill" 🔑
 *   **Problem**: Scripts with `API_KEY = "PLACEHOLDER"` are annoying.
 *   **Solution**: A Regex engine hunts for keys and pre-fills them into the Python/Bash script.
 *   **Result**: Plug-and-play exploits.
+
+### 5. Multi-Provider Exploit Routing (New in v1.3.0) 🔀
+*   **Problem**: Some LLMs analyze code for vulnerabilities without issue, but refuse — or silently return an empty response — when asked to *write* a working PoC/verification script, even with authorized-assessment framing. This was observed live: a reasoning model returned nothing for a confirmed `intent_redirection` finding, while another provider produced a complete script for the identical case.
+*   **Solution — reframed prompt**: `exploit_prompt.txt` now opens with an explicit **authorization context** (this is an authorized, sandboxed assessment; the finding was already confirmed by static analysis; the script is for a remediation/QA team) and uses verification/defensive vocabulary throughout (`Security Verification Engineer` instead of `Exploit Developer`, "reproduce an already-confirmed finding" instead of "demonstrate a vulnerability"). This alone resolves refusals on some models.
+*   **Solution — per-stage routing**: if a specific model still refuses regardless of wording, set `llm.exploit_provider` (and optionally `llm.exploit_model`) in `settings.yaml` to send **only** the exploit-generation stage to a different, known-permissive provider — scanning/analysis keeps using your main `provider`. No extra API key needed: `exploit_provider: anthropic` reuses `anthropic_api_key`/`anthropic_model` already configured for that provider. See [Configuration → Routing `--generate-exploit`](CONFIGURATION.md#routing---generate-exploit-to-a-different-provider-exploit_provider--exploit_model).
+*   **Result**: A finding that returned nothing via the main provider produced a complete, correct verification script once routed — with zero change to the scanning pipeline or its provider.
 
 ---
 
@@ -77,15 +84,14 @@ graph TD;
     G --> H[Loop Generate Exploits];
 
     H --> I[Inject Global Context Manifest Secrets];
-    I --> J[LLM Generates Chained Exploit];
+    I --> J[Exploit-Stage LLM Generates Script];
 
-    J --> K{Exploit Output Type};
-
-    K --|Java perform|--> L[Save as JS Frida];
-    K --|adb shell|--> M[Save as SH Bash];
-    K --|requests base64|--> N[Save as PY Python];
-    K --|html deep link|--> O[Save as HTML Deep Link];
+    J --> K{First line recognized?};
+    K -- "shebang / opening token" --> L[Extension = what the first line says];
+    K -- "no / unrecognized" --> M[Fallback: whole-content keyword scan];
 ```
+
+**[v1.3.0]** `Engine._detect_poc_extension()` trusts the script's **own first line** (the shebang `exploit_prompt.txt` instructs the model to emit — `#!/bin/bash`, `#!/usr/bin/env python3`, or an opening token like `Java.perform(`/`<!DOCTYPE html>`) *before* scanning the rest of the content. This matters because a Bash script can legitimately **embed** another language — e.g. a `python3 - << 'EOF' ... EOF` heredoc, used for things Bash can't easily do alone (like background `adb logcat` monitoring). The old logic scanned the *entire* content for signal keywords (`"import "`, `"def "`, `"Java.perform"`, …) with no priority for the shebang, so a valid, directly-executable `#!/bin/bash` script with an embedded Python heredoc got saved as `.py` — a file that fails if actually run as Python. Whole-content scanning is now only a fallback for the rare response that doesn't start with a recognized signal.
 
 ---
 
@@ -126,3 +132,5 @@ Like the Scanner module, the Exploit Generator is powered by AI (LLM), which is 
 *   Read the code. Does the Logic make sense?
 *   Check the `adb` commands. Are the component names correct?
 *   **Trust, but Verify.** The "Auto-Verification" feature in Python scripts is a helper, not a guarantee.
+
+**If a script comes back empty:** `exploit_prompt.txt` already frames the request with authorized-assessment context and verification-focused (not offensive) vocabulary, which resolves most refusals. If a specific model still returns nothing, don't fight it with more prompt tweaking — set `llm.exploit_provider` (see [Multi-Provider Exploit Routing](#5-multi-provider-exploit-routing-new-in-v130)) to send exploit generation to a different, known-permissive provider while keeping your main provider for scanning.

--- a/document/FEATURES.md
+++ b/document/FEATURES.md
@@ -12,6 +12,8 @@
 
 - **📚 RAG with OWASP MASVS:** Findings are automatically enriched with the relevant **OWASP Mobile Application Security Verification Standard (MASVS)** ID (e.g., `MASVS-STORAGE-1`) for rules that have a MASVS mapping defined, making your reports audit-ready instantly.
 
+- **✅ Testbed-Verified Detection:** Detection quality is validated end-to-end by an opt-in semantic Golden Test (`pytest -m llm`) that scans **VulnerAppDLH v2.0.0** and asserts a **25/25 recall contract** with precision guards, across **26 rules**.
+
 ---
 
 ## 🔍 Scanning Strategy
@@ -22,6 +24,8 @@
   - **`hybrid`:** The best of both worlds — Static keywords filter the noise, AI verifies the danger.
 
 - **🏗️ Hybrid Architecture (v1.1.5):** A revolutionary "Search → Regex Filter → LLM" pipeline that drastically reduces token usage and increases speed. [Read the Docs](ARCHITECTURE_EXPLANATION.md)
+
+- **🎯 Recall Safeguard (v1.3.0):** In `hybrid` mode, first-party files matching a rule's `detection_pattern` are always deep-scanned — a strong static signal is never discarded by the AI risk-triage. [Read the Docs](ARCHITECTURE_EXPLANATION.md)
 
 - **🛡️ Smart Scope Protection:** The "Immune System" of the scanner. Automatically filters out library code (e.g., `androidx`, `google`, `r0.java`) using a combination of **Package Whitelisting** (via Manifest) and **Library Blocklisting**. [Read the Docs](EXPLOIT_GENERATOR.md#1-smart-scope-filtering-the-immune-system)
 
@@ -43,7 +47,7 @@
 
 - **🛠️ Flexible Configuration:** A simple yet powerful configuration file (`config/settings.yaml`) allows for easy management of LLM providers, models, rules, and **Decompiler Settings** (Apktool/JADX).
 
-- **🤖 Multi-Provider Support:** Run locally with **Ollama** (free & private) or scale up with **Gemini**, **Groq**, **OpenAI**, **Anthropic**, and **OpenRouter**.
+- **🤖 Multi-Provider Support:** Run locally with **Ollama** (free & private) or scale up with **Gemini**, **Groq**, **OpenAI**, **Anthropic**, **OpenRouter**, and **9Router** (a self-hosted, OpenAI-compatible router that fans out to many providers/models behind one endpoint).
 
 - **💾 Response Cache & Resume:** Every successful LLM response is cached (content-addressed by model + prompt + code). A scan interrupted by a crash or rate limit **resumes for free** on re-run — only unfinished work calls the LLM. Configurable parallelism (`max_workers`), input truncation (`max_input_chars`), and output limit (`max_tokens`) round out the cost controls. [Read the Docs](CONFIGURATION.md#performance--cost-controls)
 
@@ -52,6 +56,8 @@
 ## 💥 Output & Exploitation
 
 - **📊 Structured Security Reports:** Get detailed JSON output containing severity, confidence scores, evidence snippets, and even an "Attack Surface Map" of the application.
+
+- **🧹 Clean, De-duplicated Findings:** Overlapping rules that flag the same file (e.g. the WebView trio) are collapsed into one primary finding with an `also_detected_by` list — no lost data, far less noise. Analysis failures are reported honestly as `Error` (never silently marked "clean").
 
 - **💥 Auto-Exploit Generation:** Automatically generates actionable **Proof-of-Concept (PoC)** scripts (Bash, HTML, Python, JS) for confirmed vulnerabilities, proving the impact instantly. [Read the Docs](EXPLOIT_GENERATOR.md)
 

--- a/document/PROMPT-EXPLANATION.md
+++ b/document/PROMPT-EXPLANATION.md
@@ -17,8 +17,9 @@ Defines the core "Identity" of the AI. This file sets the standards and rules th
 **Key Roles:**
 *   Establishes the role as a "World-Class Android Security Tester".
 *   Enforces output in valid JSON format.
-*   **[NEW]** Mandates analysis based on **OWASP MASVS** principles.
-*   **[NEW]** Serves as the entry point for "Context Injection" (where specific MASVS rule definitions are dynamically injected by the Engine at runtime).
+*   Mandates analysis based on **OWASP MASVS** principles.
+*   Serves as the entry point for "Context Injection" (where specific MASVS rule definitions are dynamically injected by the Engine at runtime).
+*   **[v1.3.0]** The Engine also appends a strict `JSON_ONLY_SUFFIX` after every rule prompt as the *final* instruction — reinforcing "JSON object only, no prose/markdown" to override any prose-inviting wording. Non-empty-but-unparseable replies are marked `status: "Error"`, never silently treated as clean.
 
 ### 2. `summarize_prompt.txt` (Phase 1: The Signal Seeker)
 **Location:** `config/prompts/summarize_prompt.txt`
@@ -38,15 +39,17 @@ Acts as an intelligent filter. The AI reads the *summaries* (from Phase 1) and d
 *   If the summary contains MASVS keywords -> Risk = **YES**.
 *   If the summary only contains common UI/Utility code -> Risk = **NO**.
 *   **Token Efficiency:** Prevents irrelevant files from entering the expensive Phase 3.
+*   **[v1.3.0] Recall safeguard:** a coarse "NO" here cannot hide a strong static signal — first-party files whose content matches an enabled rule's `detection_pattern` are deep-scanned anyway (`Engine._pattern_matched_files`). So this gate only ever *adds* scan candidates on top of the pattern hits, it never removes one.
 
 ### 4. `app_summary_prompt.txt` (Reporting: The Big Picture)
 **Location:** `config/prompts/app_summary_prompt.txt`
 **Function:** 
-Used at the end of the scan process to generate the opening paragraph of the final report (Executive Summary).
+Used at the end of the scan process to generate the opening paragraph of the final report (Executive Summary). This field is **report-only** — it is not re-injected as context into any other prompt.
 **Key Roles:**
 *   Reads `AndroidManifest.xml` (Permissions, Activities).
 *   Reads code summaries found during analysis.
-*   **[NEW]** Generates an application description focusing on: Core Functionality, Security Features, Data Handling, and Dangerous Permissions.
+*   Generates an application description focusing on: Core Functionality, Security Features, Data Handling, and Dangerous Permissions.
+*   **[v1.3.0]** Rewritten for information density: a ~120-180 word bullet-point summary, not a comprehensive essay. Prioritizes the **exported attack surface** (the most report-relevant section), states dangerous permissions actually present instead of enumerating absent ones, and forbids markdown tables/headers and closing disclaimers. Cut real-world output from ~1000-1600 tokens to ~360 tokens with no loss of security-relevant content (verified live against VulnerAppDLHv2).
 
 ### 5. `attack_surface_prompt.txt` (Reporting: The Map Maker)
 **Location:** `config/prompts/attack_surface_prompt.txt`
@@ -55,7 +58,20 @@ Used if the `generate_attack_surface_map` option is enabled. Its task is to map 
 **Key Roles:**
 *   Analyzes components where `exported=true` (Activity, Receiver, Service).
 *   Identifies Deep Link URLs that can be triggered externally.
-*   **Output:** Used by pentesters to identify initial attack vectors.
+*   **Output:** a compact **structured JSON inventory** (`report["attack_surface_map"]`), not a narrative report.
+*   **[v1.3.0]** Rewritten from a free-text "generate an attack surface map" essay to a strict JSON-inventory spec: `exported_activities`/`exported_receivers`/`exported_services`/`exported_providers` (short class names), `deep_links` (scheme/host/handler triples), `unprotected_broadcasts`, `network`/`file_io`/`ipc`/`deserialization`/`reflection` signals, and `manifest_flags`. No prose, no per-item impact commentary (that's already covered by the per-file vulnerability findings). `Engine.generate_attack_surface_map` now parses the response into a real dict (reusing `_parse_llm_response`) instead of storing raw LLM text; on failure it returns `{"error": ...}` instead of silently returning nothing. Cut real-world output from ~16,000 chars (~4000 tokens) of markdown to ~900 chars (~230 tokens) on VulnerAppDLHv2, with no loss of the underlying facts — a downstream report renderer (e.g. an HTML dashboard) is expected to turn this data into bullets/tables itself.
+
+### 6. `vuln_rules/*.yaml` (Phase 3: The Detectors)
+**Location:** `config/prompts/vuln_rules/*.yaml`
+**Function:**
+One file per vulnerability rule. Each supplies the `prompt` shown to the LLM during Deep Analysis, plus an optional `detection_pattern` (regex) and `keywords` used by the static filter to decide whether the rule even runs (per-rule gating).
+**Key Roles:**
+*   **[v1.3.0] Consistent template:** every rule follows *Vulnerability pattern → Tainted source → "not a finding if…"*, so the model reasons about attacker-controllability, not just keyword presence.
+*   **[v1.3.0] Language-agnostic:** prompts say "decompiled Android code (Java or Smali)" with a neutral ```` ``` ```` code fence — no per-file `smali→java` string patching anymore.
+*   **[v1.3.0] Per-rule gating:** in `hybrid`/`static_only` modes a rule's LLM call is skipped when its `detection_pattern` doesn't match the file (huge token saving). Pattern-less rules (e.g. `universal_logic_flaw`, deliberately LLM-exclusive) always run on risky files.
+*   **Manifest rules** (`exported_components`, `intent_spoofing`, `deeplink_hijack`, `webview_deeplink`, `strandhogg`) run only against `AndroidManifest.xml`, never the code scan (single-source `MANIFEST_RULES`).
+*   **[v1.3.0] 26 toggleable rules** (A–Z in `RulesSettings`), including the new `intent_redirection` (confused-deputy IPC). A separate `library_vulnerability` supply-chain detector runs only under `--scan-libraries`.
+*   **Output:** the structured JSON defined by the system prompt; overlapping findings on the same file are later collapsed via report de-duplication (`also_detected_by`).
 
 ---
 

--- a/document/RULES.md
+++ b/document/RULES.md
@@ -6,44 +6,78 @@
 
 ## Overview
 
-Droid LLM Hunter ships with **25 vulnerability rules** covering the most critical Android security categories, all mapped to the **OWASP MASVS** framework.
+Droid LLM Hunter ships with **26 vulnerability rules** covering the most critical Android security categories, all mapped to the **OWASP MASVS** framework. Rules are grouped by category below (mirroring the testbed reference in [VulnerAppDLH/VULNER_DLH.md](https://github.com/roomkangali/VulnerAppDLH/blob/main/VULNER_DLH.md)).
 
-Enable or disable rules in `config/settings.yaml`:
-
-- `true`: Enable the rule (included in every scan).
-- `false`: Disable the rule (skipped entirely).
+Enable or disable rules in `config/settings.yaml` (`true` = included in every scan, `false` = skipped).
 
 ---
 
-## Rule List
+### 💉 Injection & Input Validation
 
-| Rule | Category | MASVS |
-|------|----------|-------|
-| `sql_injection` | Injection | MASVS-CODE |
-| `graphql_injection` | Injection | MASVS-CODE |
-| `path_traversal` | Injection | MASVS-STORAGE |
-| `webview_xss` | WebView | MASVS-CODE |
-| `webview_deeplink` | WebView | MASVS-CODE |
-| `insecure_webview` | WebView | MASVS-CODE |
-| `webview_file_access` | WebView | MASVS-STORAGE |
-| `hardcoded_secrets` | Secrets | MASVS-STORAGE |
-| `hardcoded_secrets_xml` | Secrets | MASVS-STORAGE |
-| `exported_components` | Components | MASVS-PLATFORM |
-| `intent_spoofing` | Components | MASVS-PLATFORM |
-| `deeplink_hijack` | Components | MASVS-PLATFORM |
-| `strandhogg` | Components | MASVS-PLATFORM |
-| `pending_intent_hijacking` | Components | MASVS-PLATFORM |
-| `insecure_random_number_generation` | Crypto/Auth | MASVS-CRYPTO |
-| `biometric_bypass` | Crypto/Auth | MASVS-AUTH |
-| `insecure_deserialization` | Crypto/Auth | MASVS-CODE |
-| `insecure_storage` | Storage | MASVS-STORAGE |
-| `insecure_file_permissions` | Storage | MASVS-STORAGE |
-| `unsafe_reflection` | Code Exec | MASVS-CODE |
-| `fragment_injection` | Code Exec | MASVS-PLATFORM |
-| `universal_logic_flaw` | Logic | MASVS-CODE |
-| `deeplink_logic_bypass` | Logic | MASVS-PLATFORM |
-| `jetpack_compose_security` | Logic | MASVS-CODE |
-| `zip_slip` | Zip/Supply | MASVS-CODE |
+| Rule | Description | MASVS |
+|------|-------------|-------|
+| `sql_injection` | Raw SQL built via string concatenation (`rawQuery`/`execSQL`). | MASVS-CODE-4 |
+| `graphql_injection` | GraphQL queries assembled from untrusted strings. | MASVS-CODE-4 |
+| `path_traversal` | File reads on unvalidated user paths (`../`). | MASVS-CODE-4 |
+| `zip_slip` | Archive extraction without a canonical-path check (`../` entry names). | MASVS-CODE-4 |
+
+### 🌐 WebView Security
+
+| Rule | Description | MASVS |
+|------|-------------|-------|
+| `webview_xss` | `setJavaScriptEnabled(true)` / `addJavascriptInterface` on untrusted content. | MASVS-PLATFORM-2 |
+| `insecure_webview` | Dangerous `WebSettings` (file/universal access). | MASVS-PLATFORM-2 |
+| `webview_deeplink` | Intent-delivered URLs loaded straight into a WebView (open redirect). | MASVS-PLATFORM-2 |
+| `webview_file_access` | File access enabled in a WebView (local file/cookie theft). | MASVS-PLATFORM-2 |
+
+### 🔑 Secrets & Storage
+
+| Rule | Description | MASVS |
+|------|-------------|-------|
+| `hardcoded_secrets` | API keys / tokens hardcoded in code (`AIza…`, `AKIA…`, etc.). | MASVS-STORAGE-2 |
+| `hardcoded_secrets_xml` | Secrets embedded in `res/values/strings.xml`. | MASVS-STORAGE-2 |
+| `insecure_storage` | Plain-text credentials in `SharedPreferences`/files. | MASVS-STORAGE-1 |
+| `insecure_file_permissions` | World-readable/writable files (`MODE_WORLD_*`, `setReadable(true,false)`). | MASVS-STORAGE-1 |
+
+### 🔐 Cryptography & Authentication
+
+| Rule | Description | MASVS |
+|------|-------------|-------|
+| `insecure_random_number_generation` | Weak PRNG (`java.util.Random`) for security values. | MASVS-CRYPTO-1 |
+| `biometric_bypass` | Flawed `BiometricPrompt` / client-side auth trust. | MASVS-AUTH-2 |
+
+### 🔄 IPC (Inter-Process Communication)
+
+| Rule | Description | MASVS |
+|------|-------------|-------|
+| `exported_components` | Activities/Services/Providers exported without permission. | MASVS-PLATFORM-1 |
+| `intent_spoofing` | Broadcast receivers trusting unvalidated intents. | MASVS-PLATFORM-1 |
+| `deeplink_hijack` | Overly broad deep links (`host="*"`, missing `autoVerify`). | MASVS-PLATFORM-1 |
+| `deeplink_logic_bypass` | Auth/IDOR bypass via deep-link parameters. | MASVS-PLATFORM-1 |
+| `intent_redirection` | Forwarding an attacker's nested Intent unvalidated (confused deputy). | MASVS-PLATFORM-1 |
+| `pending_intent_hijacking` | Mutable `PendingIntent` on an implicit Intent. | MASVS-PLATFORM-1 |
+| `fragment_injection` | Exported `PreferenceActivity` with a permissive `isValidFragment()`. | MASVS-PLATFORM-1 |
+| `strandhogg` | Task hijacking via `taskAffinity` + `launchMode`. | MASVS-PLATFORM-3 |
+
+### 🧨 Deserialization, Reflection & Code Execution
+
+| Rule | Description | MASVS |
+|------|-------------|-------|
+| `insecure_deserialization` | `ObjectInputStream.readObject()` on untrusted bytes (RCE). | MASVS-CODE-4 |
+| `unsafe_reflection` | `Class.forName`/`Method.invoke` driven by untrusted input. | MASVS-CODE-4 |
+
+### 🧩 Advanced Logic & UI
+
+| Rule | Description | MASVS |
+|------|-------------|-------|
+| `universal_logic_flaw` | Conceptual/business-logic flaws (LLM-exclusive, no static pattern). | MASVS-CODE |
+| `jetpack_compose_security` | Security misconfigurations in Jetpack Compose UI. | MASVS-PLATFORM-3 |
+
+---
+
+### 🕵️ Library Hunter Mode (supply-chain, opt-in)
+
+Beyond the 26 rules above, a dedicated **`library_vulnerability`** detector runs only under `--scan-libraries`. It bypasses Smart Scope Protection to audit **third-party SDKs** for backdoors, droppers (`DexClassLoader`), native/command execution, device-identifier spyware, and unsafe JS bridges. It is activated by the flag rather than a `settings.yaml` toggle.
 
 ---
 
@@ -56,31 +90,27 @@ rules:
   sql_injection: true
   webview_xss: true
   hardcoded_secrets: true
-  insecure_storage: false   # disabled
-  zip_slip: false           # disabled
+  intent_redirection: false   # disabled
+  zip_slip: false             # disabled
   # ... etc
 ```
 
-Or use the CLI:
+> **Note:** editing `settings.yaml` by hand preserves the inline comments. The `python dlh.py config rules --enable/--disable` commands rewrite the file via a YAML dumper and will strip those comments.
+
+Or list rules from the CLI:
 
 ```bash
-# Enable rules
-python dlh.py config rules --enable sql_injection,webview_xss
-
-# Disable rules
-python dlh.py config rules --disable zip_slip,insecure_storage
-
-# List all available rules
-python dlh.py --list-rules
+python dlh.py list-rules
 ```
 
 ---
 
 ## How to Add a New Rule
 
-1. Create a new YAML file in `config/prompts/vuln_rules/` (containing `name`, `description`, and `prompt`).
-2. Add the rule to the `RulesSettings` class in `core/config_loader.py`.
-3. Add the rule entry to `config/settings.yaml`.
-4. *(Optional)* Add a mapping entry in `config/knowledge_base/masvs_mapping.json` to link to an OWASP MASVS category.
+1. Create a new YAML file in `config/prompts/vuln_rules/` (`name`, `description`, `prompt`, optional `detection_pattern` + `keywords`).
+2. Add the rule to the `RulesSettings` class in `core/config_loader.py` (keep it A–Z).
+3. Add the rule entry to `config/settings.yaml` (with an inline comment).
+4. Add a mapping entry in `config/knowledge_base/masvs_mapping.json` (OWASP MASVS).
+5. Add Layer-1 golden coverage in `tests/test_detection_patterns.py` (a sample the `detection_pattern` must match), and — if the testbed exercises it — a `{rule → file}` entry in `tests/golden/vulnerapp_expected.json`.
 
 Contributions of new rules are always welcome — see [Contributing](../README.md#contributing).

--- a/document/SCAN-WORKFLOW.md
+++ b/document/SCAN-WORKFLOW.md
@@ -11,7 +11,7 @@ Droid LLM Hunter uses a multi-stage process to analyze an APK:
 1.  **Decompilation:** The APK is decompiled using **Apktool** (for Smali/Manifest) and optionally **JADX** (for Java Source), depending on the `decompiler_mode`.
 2.  **Smart Filtering:** Based on the `filter_mode`, the engine identifies potentially risky files using Static Analysis (`static_only`), AI Summarization (`llm_only`), or both (`hybrid`).
 3.  **Smart Scope Protection:** Irrelevant files (libraries) are discarded based on `package` name and blocklists.
-4.  **Risk Identification:** High-level analysis determines which files require deep inspection.
+4.  **Risk Identification:** High-level analysis determines which files require deep inspection. **[v1.3.0]** As a recall safeguard, first-party files whose content matches an enabled rule's `detection_pattern` skip this triage and are always deep-scanned (a strong static signal is never dropped).
 5.  **Deep Dive Analysis:** Risky files are scanned for vulnerabilities.
 6.  **Global Context Building:** All findings are summarized to create a "Global Context".
 7.  **Chained Exploit Generation:** The engine generates exploits that leverage the Global Context to connect vulnerabilities across files.
@@ -104,4 +104,16 @@ Droid LLM Hunter uses a multi-stage process to analyze an APK:
 
 ## JSON Report Structure
 
-For more detailed information on the **JSON Report** structure, see the [output/](../output/) directory for example reports.
+The report is a JSON object with:
+- **`app_summary`** — executive summary of the app's capabilities.
+- **`attack_surface_map`** — entry-point map (only if `generate_attack_surface_map` is enabled).
+- **`results`** — a list of findings. Each has `file`, `rule`, `vulnerability` (name), `status`
+  (`Vulnerable` / `Not Vulnerable` / `Error`), and a structured `result` (severity, confidence,
+  evidence, description, attack_scenario, recommendation, MASVS reference, …).
+  - **[v1.3.0] `also_detected_by`** — when several overlapping rules flag the SAME file (e.g. the
+    WebView trio, or the broad `universal_logic_flaw`), they are collapsed into one primary finding
+    and the rest are listed here — nothing is lost, the report is just less noisy.
+- **[v1.2.0] `analysis_errors`** — file/rule checks that could NOT be analyzed (empty or unparseable
+  LLM response). These are `status: "Error"` and must be treated as **unanalyzed, not clean**.
+
+For example reports, see the [output/](../output/) directory.

--- a/modules/llm_client/router9.py
+++ b/modules/llm_client/router9.py
@@ -1,0 +1,122 @@
+import requests
+import json
+import time
+from .base import BaseLLMClient
+from core import log
+from typing import Dict, Any
+
+
+class Router9Client(BaseLLMClient):
+    """Client for 9Router — a self-hosted, OpenAI-compatible LLM router that fans out
+    to many providers/models behind ONE endpoint (e.g. model="gc/gemini-2.5-pro" routes
+    through to Gemini). `base_url` is configurable since it's self-hosted (host/port vary
+    per install), unlike the other clients in this package which hit a fixed public URL.
+
+    Unlike those other OpenAI-compatible clients, 9Router's /v1/chat/completions endpoint
+    was observed to return a Server-Sent Events (SSE) stream even for a plain request with
+    no `"stream"` key set — responses arrive as `data: {...}` chunks with `chat.completion.chunk`
+    objects and per-token `delta.content` fragments, not a single JSON body. This client
+    detects that via the `Content-Type` response header and parses accordingly, falling
+    back to a normal single-JSON response if the router ever returns one instead.
+    """
+
+    def __init__(self, model: str, api_key: str, base_url: str, max_tokens: int = 4096):
+        self.model = model
+        self.api_key = api_key
+        self.max_tokens = max_tokens
+        self.url = base_url
+
+    def analyze_code(self, code_snippet: str, context: Dict[str, Any]) -> str:
+        prompt = self._construct_prompt(code_snippet, context)
+        log.info(f"Sending analysis request to 9Router model: {self.model}...")
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        data = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": prompt
+                }
+            ]
+        }
+
+        max_retries = 3
+        base_delay = 2  # seconds
+
+        for attempt in range(max_retries):
+            try:
+                response = requests.post(
+                    self.url, headers=headers, data=json.dumps(data),
+                    timeout=120, stream=True,
+                )
+
+                if response.status_code == 429:
+                    log.warning(f"Rate limit hit (429). Retrying... (Attempt {attempt + 1})")
+                    time.sleep(base_delay * (2 ** attempt))
+                    continue
+
+                response.raise_for_status()
+
+                content_type = response.headers.get("Content-Type", "")
+                if "text/event-stream" in content_type:
+                    content = self._parse_sse_stream(response)
+                else:
+                    result = response.json()
+                    if "error" in result:
+                        log.error(f"9Router API returned error: {result['error']}")
+                        raise requests.exceptions.RequestException(f"9Router API Error: {result['error']}")
+                    choices = result.get("choices") or []
+                    content = choices[0]["message"]["content"] if choices else ""
+
+                if content:
+                    log.success("Received analysis from 9Router.")
+                return content
+
+            except requests.exceptions.RequestException as e:
+                log.warning(f"Network error: {e}. Retrying...")
+                time.sleep(base_delay * (2 ** attempt))
+
+        log.error(f"9Router API failed after {max_retries} attempts.")
+        return ""
+
+    def _parse_sse_stream(self, response) -> str:
+        """Accumulates `delta.content` fragments from an OpenAI-style SSE stream
+        (`data: {...}` lines, terminated by `data: [DONE]`)."""
+        chunks = []
+        for raw_line in response.iter_lines(decode_unicode=True):
+            if not raw_line or not raw_line.startswith("data:"):
+                continue
+            payload = raw_line[len("data:"):].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                event = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if "error" in event:
+                log.error(f"9Router stream returned error: {event['error']}")
+                continue
+            choices = event.get("choices") or []
+            if not choices:
+                continue
+            delta = choices[0].get("delta") or {}
+            piece = delta.get("content")
+            if piece:
+                chunks.append(piece)
+        return "".join(chunks)
+
+    def _construct_prompt(self, code_snippet: str, context: Dict[str, Any]) -> str:
+        system_prompt = context.get("system_prompt", "")
+        vuln_prompt = context.get("vuln_prompt", "")
+
+        formatted_prompt = vuln_prompt.format(
+            code_snippet=code_snippet,
+            file_path=context.get("file_path", "N/A")
+        )
+
+        return f"{system_prompt}\n\n{formatted_prompt}"

--- a/modules/llm_client/router9.py
+++ b/modules/llm_client/router9.py
@@ -50,29 +50,31 @@ class Router9Client(BaseLLMClient):
 
         for attempt in range(max_retries):
             try:
-                response = requests.post(
-                    self.url, headers=headers, data=json.dumps(data),
-                    timeout=120, stream=True,
-                )
+                with requests.post(
+                    self.url,
+                    headers=headers,
+                    json=data,
+                    timeout=120,
+                    stream=True,
+                ) as response:
 
-                if response.status_code == 429:
-                    log.warning(f"Rate limit hit (429). Retrying... (Attempt {attempt + 1})")
-                    time.sleep(base_delay * (2 ** attempt))
-                    continue
+                    if response.status_code == 429:
+                        log.warning(f"Rate limit hit (429). Retrying... (Attempt {attempt + 1})")
+                        time.sleep(base_delay * (2 ** attempt))
+                        continue
 
-                response.raise_for_status()
+                    response.raise_for_status()
 
-                content_type = response.headers.get("Content-Type", "")
-                if "text/event-stream" in content_type:
-                    content = self._parse_sse_stream(response)
-                else:
-                    result = response.json()
-                    if "error" in result:
-                        log.error(f"9Router API returned error: {result['error']}")
-                        raise requests.exceptions.RequestException(f"9Router API Error: {result['error']}")
-                    choices = result.get("choices") or []
-                    content = choices[0]["message"]["content"] if choices else ""
-
+                    content_type = response.headers.get("Content-Type", "")
+                    if "text/event-stream" in content_type:
+                        content = self._parse_sse_stream(response)
+                    else:
+                        result = response.json()
+                        if "error" in result:
+                            log.error(f"9Router API returned error: {result['error']}")
+                            raise requests.exceptions.RequestException(f"9Router API Error: {result['error']}")
+                        choices = result.get("choices") or []
+                        content = choices[0]["message"]["content"] if choices else ""
                 if content:
                     log.success("Received analysis from 9Router.")
                 return content

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,7 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
-addopts = -q
+# Layer 1 (deterministic) runs by default; Layer 2 (LLM, paid) is opt-in via `-m llm`.
+addopts = -q -m "not llm"
+markers =
+    llm: semantic Golden Test Layer 2 — calls a real LLM (paid/slow). Opt-in: `pytest -m llm`.

--- a/tests/golden/vulnerapp_expected.json
+++ b/tests/golden/vulnerapp_expected.json
@@ -1,0 +1,69 @@
+{
+  "_about": "Layer-2 semantic recall baseline for VulnerAppDLHv2. Ground truth derived from the app's SOURCE CODE (see VulnerAppDLH/VULNER_DLH.md + the .kt sources), not from a past scan. The Layer-2 harness runs a scan of VulnerAppDLHv2.apk and asserts findings COVER 'expected' (recall contract) and respect 'must_not_fire' (precision guards).",
+  "app": "VulnerAppDLHv2.apk",
+  "derived_from": "source-code ground truth (2026-07); v2 testbed expansion 2026-07-27",
+  "matching": "Compare by filename STEM (extension-agnostic): 'SQLInjectionActivity' matches SQLInjectionActivity.java/.kt/.smali; 'AndroidManifest' matches AndroidManifest.xml; 'strings' matches res/values/strings.xml. Assert on RAW findings (before [E] report-dedup).",
+  "harness_notes": "The scan MUST enable all rules listed under 'expected' (they are off by default in settings.yaml). Record which model produced this baseline; re-record if the model changes (recall is model-sensitive).",
+  "baseline_model": "moonshotai/kimi-k3 (OpenRouter)",
+  "baseline_recorded": "2026-07-26 (v1, 16 TPs); v2 expansion verified 2026-07-27 (floor 25/25)",
+  "baseline_recall": "VERIFIED 25/25 with kimi-k3 on 2026-07-27 (recall + precision green). Floor = 16 v1 TPs + 8 v2 TPs + hardcoded_secrets on WebViewActivity (a real getSecrets() token the v1 baseline had omitted).",
+
+  "v2_verification_resolved": {
+    "_note": "Both anticipated v2 risks were hit and fixed during Phase 4 verification.",
+    "pending_intent_hijacking": "CONFIRMED: JADX inlined FLAG_MUTABLE -> 33554432, so the literal-only pattern missed it. Fixed: detection_pattern now matches (FLAG_MUTABLE|33554432).",
+    "zip_slip": "CONFIRMED: pattern matched but the LLM risk-triage (identify_risky_chunks) dropped ZipSlipActivity before rule gating. Fixed: engine now deep-scans first-party files that match a detection_pattern, bypassing the triage (Engine._pattern_matched_files).",
+    "hardcoded_secrets_xml": "CONFIRMED: finding file stem is 'strings' (res/values/strings.xml)."
+  },
+
+  "closed_gaps_v1_2_1": {
+    "insecure_file_permissions": "T2.2a — added set(Readable|Writable)(true,false) to detection_pattern + prompt; app used setReadable(true,false), not MODE_WORLD_* constants.",
+    "universal_logic_flaw": "T3.4a — removed narrow detection_pattern so per-rule gating (#1) no longer skips conceptual flaws; now LLM-exclusive, runs on all risky files."
+  },
+
+  "expected": {
+    "sql_injection": ["SQLInjectionActivity"],
+    "webview_xss": ["WebViewActivity"],
+    "insecure_webview": ["WebViewActivity"],
+    "webview_file_access": ["WebViewActivity"],
+    "graphql_injection": ["GraphQLInjectionActivity"],
+    "path_traversal": ["InsecureFileActivity"],
+    "insecure_file_permissions": ["InsecureFileActivity"],
+    "hardcoded_secrets": ["SecretsActivity", "WebViewActivity"],
+    "insecure_storage": ["SecretsActivity"],
+    "insecure_random_number_generation": ["CryptoActivity"],
+    "biometric_bypass": ["CryptoActivity"],
+    "universal_logic_flaw": ["CryptoActivity"],
+    "exported_components": ["AndroidManifest"],
+    "intent_spoofing": ["AndroidManifest"],
+    "deeplink_hijack": ["AndroidManifest"],
+    "webview_deeplink": ["AndroidManifest"],
+
+    "insecure_deserialization": ["DeserializationActivity"],
+    "unsafe_reflection": ["ReflectionActivity"],
+    "pending_intent_hijacking": ["PendingIntentActivity"],
+    "zip_slip": ["ZipSlipActivity"],
+    "intent_redirection": ["IntentRedirectionActivity"],
+    "fragment_injection": ["FragmentInjectionActivity"],
+    "strandhogg": ["AndroidManifest"],
+    "hardcoded_secrets_xml": ["strings"]
+  },
+
+  "optional": {
+    "_note": "Plausible true-positives the code supports but not required for the recall contract. NOTE: universal_logic_flaw also over-fires on SpoofableReceiver & UnprotectedExportedActivity (trust-of-external-input) — known broad-ULF behavior, NOT a precision violation (must_not_fire guards only library files).",
+    "deeplink_logic_bypass": ["WebViewActivity", "UnprotectedExportedActivity"],
+    "path_traversal": ["ZipSlipActivity"],
+    "hardcoded_secrets": ["SQLInjectionActivity"]
+  },
+
+  "must_not_fire": {
+    "_note": "Precision guards. strandhogg is now a REAL TP in v2 (HijackTargetActivity manifest) so it was removed from here. universal_logic_flaw must not fire on library internals (it over-fired 1 TP : 8 FP in past scans — see [D]).",
+    "universal_logic_flaw": ["DebugProbesImpl", "FastServiceLoader"]
+  },
+
+  "uncovered_rules": {
+    "_note": "Rules DLH supports that VulnerAppDLHv2 does NOT exercise. Only jetpack_compose_security remains (it needs Jetpack Compose; it will get its own separate Compose testbed app later).",
+    "rules": [
+      "jetpack_compose_security"
+    ]
+  }
+}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,7 +21,7 @@ def test_rules_are_alphabetical():
 
 
 def test_rule_count_stable():
-    assert len(RulesSettings.model_fields) == 25
+    assert len(RulesSettings.model_fields) == 26
 
 
 def test_gemini_api_key_field_is_consistent():
@@ -30,7 +30,68 @@ def test_gemini_api_key_field_is_consistent():
     assert "api_key" not in LLMSettings.model_fields
 
 
+def test_app_summary_prompt_is_format_safe_and_dense():
+    """v1.3.0: app_summary_prompt.txt was rewritten to produce a dense executive
+    summary (was ~1000-1600 tokens of markdown essay; observed ~360 tokens after).
+    Guard against regressions: must still .format() safely (no stray braces) and
+    must explicitly instruct a word budget + against permission-absence enumeration."""
+    with open("config/prompts/app_summary_prompt.txt") as f:
+        prompt = f.read()
+    prompt.format(manifest="<manifest/>", summaries="x")  # raises on stray { }
+    assert "words" in prompt.lower()  # an explicit length budget is present
+    assert "do not enumerate" in prompt.lower()
+
+
+def test_attack_surface_prompt_is_format_safe_and_json_only():
+    """v1.3.0: attack_surface_prompt.txt was rewritten from a narrative-report prompt
+    to a compact JSON-inventory prompt (see Engine.generate_attack_surface_map).
+    It must still .format() safely (no stray braces — no literal JSON example is
+    used in the template for exactly this reason) and must demand JSON-only output."""
+    with open("config/prompts/attack_surface_prompt.txt") as f:
+        prompt = f.read()
+    prompt.format(manifest="<manifest/>", summaries="x")  # raises on stray { }
+    assert "json" in prompt.lower()
+    assert "no prose" in prompt.lower() or "not a report" in prompt.lower()
+
+
+def test_exploit_provider_fields_exist_and_default_unset():
+    # v1.3.0: route --generate-exploit to a different provider/model than scanning
+    # (some models refuse/empty exploit-gen requests). Both optional, default None
+    # so this is fully backward compatible / opt-in.
+    assert "exploit_provider" in LLMSettings.model_fields
+    assert "exploit_model" in LLMSettings.model_fields
+    assert LLMSettings.model_fields["exploit_provider"].default is None
+    assert LLMSettings.model_fields["exploit_model"].default is None
+
+
+def test_router9_provider_fields_exist():
+    # v1.3.0: 9Router (self-hosted, OpenAI-compatible multi-provider router).
+    # Field prefix is "router9" (not "9router") because Pydantic/Python identifiers
+    # can't start with a digit.
+    for field in ("router9_model", "router9_api_key", "router9_base_url"):
+        assert field in LLMSettings.model_fields
+
+
 def test_new_v120_settings_exist():
     for field in ("max_workers", "use_cache", "max_input_chars"):
         assert field in __import__("core.config_loader", fromlist=["AnalysisSettings"]).AnalysisSettings.model_fields
     assert "max_tokens" in LLMSettings.model_fields
+
+
+def test_golden_baseline_is_well_formed():
+    """Deterministic guard for the Layer-2 baseline: every rule key is real (Layer-2 test itself is opt-in)."""
+    import json
+    import os
+
+    repo = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    baseline = json.load(open(os.path.join(repo, "tests", "golden", "vulnerapp_expected.json")))
+    valid_rules = set(RulesSettings.model_fields)
+
+    for rule in baseline["expected"]:
+        assert rule in valid_rules, f"baseline 'expected' has unknown rule: {rule}"
+        assert isinstance(baseline["expected"][rule], list) and baseline["expected"][rule]
+    for rule in baseline.get("must_not_fire", {}):
+        if not rule.startswith("_"):
+            assert rule in valid_rules, f"baseline 'must_not_fire' has unknown rule: {rule}"
+    for rule in baseline.get("uncovered_rules", {}).get("rules", []):
+        assert rule in valid_rules, f"baseline 'uncovered_rules' has unknown rule: {rule}"

--- a/tests/test_detection_patterns.py
+++ b/tests/test_detection_patterns.py
@@ -43,6 +43,7 @@ POSITIVE = {
     "insecure_random_number_generation": "Random r = new Random();",
     "insecure_storage": 'getSharedPreferences("p", MODE_PRIVATE);',
     "insecure_webview": 'webView.addJavascriptInterface(new Bridge(), "app");',
+    "intent_redirection": 'Intent fwd = (Intent) intent.getParcelableExtra("i"); startActivity(fwd);',
     "intent_spoofing": '<receiver android:name=".R" android:exported="true"/>',
     "jetpack_compose_security": "@Composable fun LoginScreen() {}",
     "library_vulnerability": "DexClassLoader cl = new DexClassLoader(path, opt, null, parent);",
@@ -50,15 +51,16 @@ POSITIVE = {
     "pending_intent_hijacking": "PendingIntent.getActivity(ctx, 0, i, PendingIntent.FLAG_MUTABLE);",
     "sql_injection": 'db.rawQuery("SELECT * FROM u WHERE n=" + name, null);',
     "unsafe_reflection": 'Class.forName(intent.getStringExtra("cls"));',
-    "universal_logic_flaw": "public boolean shouldOverrideUrlLoading(WebView v, String url) {",
     "webview_deeplink": '<action android:name="android.intent.action.VIEW"/>',
     "webview_file_access": "settings.setAllowFileAccess(true);",
     "webview_xss": "settings.setJavaScriptEnabled(true);",
     "zip_slip": "for (ZipEntry e : zip.entries()) { new File(dir, e.getName()); }",
 }
 
-# Rules that intentionally have NO detection_pattern (keyword-only / manifest heuristic).
-NO_PATTERN = {"strandhogg", "hardcoded_secrets_xml"}
+# Rules that intentionally have NO detection_pattern (keyword-only / manifest heuristic /
+# LLM-exclusive). universal_logic_flaw is LLM-exclusive (v1.3.0 T3.4a): no pattern so gating
+# never skips a conceptual flaw.
+NO_PATTERN = {"strandhogg", "hardcoded_secrets_xml", "universal_logic_flaw"}
 
 
 def test_every_rule_has_golden_coverage():
@@ -85,6 +87,13 @@ def test_all_detection_patterns_compile():
             re.compile(pat)  # raises re.error if invalid
 
 
+def test_all_rule_prompts_are_format_safe():
+    """Every rule prompt must survive str.format(code_snippet=, file_path=) — no stray { } braces."""
+    for rule in _all_rules():
+        prompt = _load(rule).get("prompt", "")
+        prompt.format(code_snippet="X", file_path="Y")  # raises KeyError/ValueError on stray braces
+
+
 def test_fragment_injection_matches_both_java_and_smali():
     """Regression for the v1.2.0 [B] fix: this rule was Smali-only and dead in hybrid mode."""
     rx = re.compile(_load("fragment_injection")["detection_pattern"])
@@ -96,7 +105,60 @@ def test_fragment_injection_matches_both_java_and_smali():
     ("fragment_injection", "public class X extends Activity {"),
     ("sql_injection", "int total = a + b;"),
     ("insecure_random_number_generation", "int x = getRandomFromSecureSource();"),
+    # v1.3.0 [D]: path_traversal no longer matches openFileOutput coincidentally
+    ("path_traversal", 'openFileOutput("public.txt", MODE_PRIVATE);'),
+    # v1.3.0 [D]: graphql no longer matches any "query = ..." assignment
+    ("graphql_injection", 'String query = "SELECT * FROM users WHERE id=" + id;'),
 ])
 def test_negative_cases_do_not_match(rule, benign):
     rx = re.compile(_load(rule)["detection_pattern"])
     assert not rx.search(benign), f"'{rule}' pattern should NOT match benign code: {benign!r}"
+
+
+def test_path_traversal_matches_real_read_signal():
+    """v1.3.0 [D]: path_traversal must match the real signal (FileInputStream/ContentProvider openFile)."""
+    rx = re.compile(_load("path_traversal")["detection_pattern"])
+    assert rx.search("FileInputStream in = new FileInputStream(new File(dir, name));")
+    assert rx.search("public ParcelFileDescriptor openFile(Uri uri, String mode) {")
+
+
+def test_insecure_file_permissions_covers_setreadable():
+    """v1.3.0 T2.2a: baseline gap — app uses File.setReadable(true, false), not MODE_WORLD_* constants."""
+    rx = re.compile(_load("insecure_file_permissions")["detection_pattern"])
+    assert rx.search("file.setReadable(true, false);")   # world-readable -> must match
+    assert rx.search("f.setWritable(true, false)")       # world-writable -> must match
+    assert not rx.search("file.setReadable(true, true);")  # owner-only -> safe, must NOT match
+    assert not rx.search("file.setReadable(true);")        # single-arg -> safe, must NOT match
+
+
+def test_pending_intent_matches_inlined_flag_mutable():
+    """v2 Layer-2 finding: JADX inlines PendingIntent.FLAG_MUTABLE to its int value
+    33554432, so the literal-only pattern missed PendingIntentActivity. The pattern must
+    match both the named constant and the decompiled integer form."""
+    rx = re.compile(_load("pending_intent_hijacking")["detection_pattern"], re.IGNORECASE | re.DOTALL)
+    assert rx.search("PendingIntent pending = PendingIntent.getActivity(this, 0, baseIntent, 33554432);")
+    assert rx.search("PendingIntent.getActivity(ctx, 0, i, PendingIntent.FLAG_MUTABLE);")
+    # a non-mutable PendingIntent (immutable flag 67108864) must NOT match
+    assert not rx.search("PendingIntent.getActivity(ctx, 0, i, 67108864);")
+
+
+def test_universal_logic_flaw_has_no_pattern():
+    """v1.3.0 T3.4a: LLM-exclusive rule must have NO detection_pattern so gating never skips it."""
+    assert not _load("universal_logic_flaw").get("detection_pattern")
+
+
+# v1.3.0 T2.2: rules whose patterns were made dual-language must also match Smali (apktool mode).
+SMALI_POSITIVE = {
+    "unsafe_reflection": "invoke-static {v0}, Ljava/lang/Class;->forName(Ljava/lang/String;)Ljava/lang/Class;",
+    "insecure_deserialization": "invoke-virtual {p0}, Ljava/io/ObjectInputStream;->readObject()Ljava/lang/Object;",
+    "pending_intent_hijacking": "Landroid/app/PendingIntent;->getActivity(...) sget Landroid/app/PendingIntent;->FLAG_MUTABLE:I",
+    "zip_slip": "invoke-virtual {v1}, Ljava/util/zip/ZipEntry;->getName()Ljava/lang/String;",
+}
+
+
+@pytest.mark.parametrize("rule", sorted(SMALI_POSITIVE))
+def test_detection_pattern_matches_smali_too(rule):
+    rx = re.compile(_load(rule)["detection_pattern"])
+    assert rx.search(SMALI_POSITIVE[rule]), f"'{rule}' should also match its Smali form (apktool mode)"
+    # and still match Java (regression)
+    assert rx.search(POSITIVE[rule]), f"'{rule}' must still match its Java form"

--- a/tests/test_golden_vulnerapp.py
+++ b/tests/test_golden_vulnerapp.py
@@ -1,0 +1,148 @@
+"""
+Golden Test — Layer 2 (SEMANTIC, calls a real LLM).
+
+Runs a full DLH scan of VulnerAppDLHv2.apk and checks the findings against the
+curated ground-truth baseline (tests/golden/vulnerapp_expected.json):
+
+  - RECALL contract: every expected {rule -> file} true-positive is detected.
+  - PRECISION guards: `must_not_fire` rules/files do NOT appear.
+
+This is OPT-IN and never runs in the default suite:
+    pytest -m llm
+
+Requirements: VulnerAppDLHv2.apk present at repo root, a configured LLM provider in
+config/settings.yaml (uses whatever provider is set), apktool + jadx installed.
+The response cache (v1.2.0) makes re-runs cheap; changing a prompt busts its key.
+"""
+import json
+import os
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.llm
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APK = os.path.join(REPO, "VulnerAppDLHv2.apk")
+BASELINE_PATH = os.path.join(REPO, "tests", "golden", "vulnerapp_expected.json")
+RULES_DIR = os.path.join(REPO, "config", "prompts", "vuln_rules")
+
+
+def _load_baseline():
+    with open(BASELINE_PATH) as f:
+        return json.load(f)
+
+
+def _rule_name(rule_key):
+    """Map a rule key (sql_injection) to the report's vulnerability name ('SQL Injection')."""
+    with open(os.path.join(RULES_DIR, rule_key + ".yaml")) as f:
+        return yaml.safe_load(f).get("name", rule_key)
+
+
+def _stem(path):
+    return os.path.splitext(os.path.basename(str(path)))[0]
+
+
+def _rules_to_enable(baseline):
+    keys = set(baseline["expected"])
+    keys |= {k for k in baseline.get("must_not_fire", {}) if not k.startswith("_") and k != "*"}
+    return sorted(keys)
+
+
+@pytest.fixture(scope="module")
+def findings():
+    """Run one scan and return {vulnerability_name -> set(file stems)} of Vulnerable results."""
+    if not os.path.exists(APK):
+        pytest.skip(f"VulnerAppDLHv2.apk not found at {APK}")
+
+    from core.config_loader import load_settings
+    from core.engine import Engine
+
+    baseline = _load_baseline()
+    rules = _rules_to_enable(baseline)
+
+    settings = load_settings()
+    for r in rules:
+        if hasattr(settings.rules, r):
+            setattr(settings.rules, r, True)
+    settings.analysis.generate_exploit = False  # findings only, no PoC
+
+    out = os.path.join(REPO, "output", "_golden_layer2_report.json")
+    engine = Engine(settings)
+    engine.run(APK, output_file=out, no_decompile=False, rules=",".join(rules))
+
+    with open(out) as f:
+        report = json.load(f)
+
+    vuln_map = {}
+    for r in report.get("results", []):
+        if str(r.get("status", "")).lower() == "vulnerable":
+            stem = _stem(r.get("file", ""))
+            vuln_map.setdefault(r.get("vulnerability"), set()).add(stem)
+            # [#E] merged/folded findings live under 'also_detected_by' — still count them.
+            for extra in (r.get("also_detected_by") or []):
+                vuln_map.setdefault(extra.get("vulnerability"), set()).add(stem)
+    return vuln_map
+
+
+def test_recall_contract(findings):
+    """
+    Regression contract: detected findings must cover the recall FLOOR
+    (expected ground-truth MINUS documented known_gaps). Dropping below the floor
+    is a regression and fails. known_gaps are pre-existing detection-pattern gaps
+    tracked for v1.3.0; if one starts getting detected, tighten the baseline.
+    """
+    baseline = _load_baseline()
+    gaps = {k: set(v) for k, v in baseline.get("known_gaps", {}).items()
+            if not k.startswith("_") and isinstance(v, list)}
+
+    total = sum(len(v) for v in baseline["expected"].values())
+    missing_floor = []        # required TPs not detected -> REGRESSION (fail)
+    gap_now_detected = []     # known gaps that DID get detected -> tighten baseline
+    gap_still_missing = 0
+
+    for rule_key, files in baseline["expected"].items():
+        name = _rule_name(rule_key)
+        detected = findings.get(name, set())
+        gap_files = gaps.get(rule_key, set())
+        for f in files:
+            if f in gap_files:
+                if f in detected:
+                    gap_now_detected.append(f"{rule_key} on {f}")
+                else:
+                    gap_still_missing += 1
+            elif f not in detected:
+                missing_floor.append(f"  - {rule_key} ({name}) expected on {f}")
+
+    floor = total - sum(len(v) for v in gaps.values())
+    hit_floor = floor - len(missing_floor)
+    summary = (f"RECALL: floor {hit_floor}/{floor} met; "
+               f"{gap_still_missing} known-gap(s) still missing; "
+               f"total ground-truth {total - len(missing_floor) - gap_still_missing}/{total}.")
+    print("\n" + summary)
+    if gap_now_detected:
+        print("known_gaps now DETECTED (consider tightening baseline): " + ", ".join(gap_now_detected))
+
+    assert not missing_floor, (
+        summary + "\nREGRESSION — recall dropped below floor:\n" + "\n".join(missing_floor)
+    )
+
+
+def test_precision_guards(findings):
+    """`must_not_fire` rules/files must NOT be reported."""
+    baseline = _load_baseline()
+    violations = []
+    for rule_key, spec in baseline.get("must_not_fire", {}).items():
+        if rule_key.startswith("_"):
+            continue
+        name = _rule_name(rule_key)
+        detected = findings.get(name, set())
+        if spec == "*":
+            if detected:
+                violations.append(f"  - {rule_key} ({name}) must NOT fire at all, but hit: {sorted(detected)}")
+        elif isinstance(spec, list):
+            bad = detected & set(spec)
+            if bad:
+                violations.append(f"  - {rule_key} ({name}) must NOT fire on library files, but hit: {sorted(bad)}")
+
+    assert not violations, "PRECISION violations:\n" + "\n".join(violations)

--- a/tests/test_pure_functions.py
+++ b/tests/test_pure_functions.py
@@ -10,6 +10,7 @@ import types
 from core.engine import Engine
 from core.llm_cache import CachedLLMClient
 from core.call_graph import CallGraphBuilder
+from modules.llm_client.router9 import Router9Client
 
 
 def _engine():
@@ -124,6 +125,384 @@ def test_cache_disabled_bypasses(tmp_path):
 
 
 # ---- cross-language call graph mapping ----------------------------------------
+def _finding(file, rule, vuln, sev="High", status="Vulnerable"):
+    return {"file": file, "rule": rule, "vulnerability": vuln, "status": status,
+            "result": {"severity": sev, "description": f"{vuln} detail"}}
+
+
+def test_dedupe_family_merge():
+    """[#E] WebView-family findings on the same file collapse to one + also_detected_by."""
+    e = _engine()
+    out = e._dedupe_findings([
+        _finding("W.java", "webview_xss", "WebView XSS", "High"),
+        _finding("W.java", "insecure_webview", "Insecure WebView", "Medium"),
+        _finding("W.java", "webview_file_access", "WebView File Access", "Low"),
+    ])
+    assert len(out) == 1
+    assert out[0]["rule"] == "webview_xss"  # highest severity kept as primary
+    also = {a["rule"] for a in out[0]["also_detected_by"]}
+    assert also == {"insecure_webview", "webview_file_access"}
+
+
+def test_dedupe_generic_fold_when_specific_present():
+    """[#E] universal_logic_flaw folds into a specific finding on the same file (kept, not dropped)."""
+    e = _engine()
+    out = e._dedupe_findings([
+        _finding("C.java", "biometric_bypass", "Biometric", "High"),
+        _finding("C.java", "universal_logic_flaw", "Conceptual Logic Flaw Detection", "Medium"),
+    ])
+    top = {r["rule"] for r in out}
+    assert "universal_logic_flaw" not in top and "biometric_bypass" in top
+    host = next(r for r in out if r["rule"] == "biometric_bypass")
+    folded = [a for a in host["also_detected_by"] if a["rule"] == "universal_logic_flaw"]
+    assert folded and folded[0]["description"]  # detail preserved
+
+
+def test_dedupe_generic_standalone_kept():
+    """[#E] universal_logic_flaw alone on a file stays as a real finding."""
+    e = _engine()
+    out = e._dedupe_findings([_finding("X.java", "universal_logic_flaw", "Conceptual Logic Flaw Detection")])
+    assert len(out) == 1 and out[0]["rule"] == "universal_logic_flaw"
+
+
+def test_dedupe_keeps_distinct_files_and_passes_through_non_vulnerable():
+    e = _engine()
+    out = e._dedupe_findings([
+        _finding("A.java", "webview_xss", "WebView XSS"),
+        _finding("B.java", "insecure_webview", "Insecure WebView"),
+        _finding("A.java", "sql_injection", "SQL Injection", status="Not Vulnerable"),
+        _finding("A.java", "path_traversal", "Path Traversal", status="Error"),
+    ])
+    # 2 distinct-file vulnerable (not merged) + 2 passthrough
+    assert len(out) == 4
+
+
+def test_json_only_suffix_is_format_safe():
+    """[#C] The appended JSON-only suffix must be brace-free (vuln_prompt goes through str.format())."""
+    from core.engine import JSON_ONLY_SUFFIX
+    assert "{" not in JSON_ONLY_SUFFIX and "}" not in JSON_ONLY_SUFFIX
+    assert "JSON" in JSON_ONLY_SUFFIX
+    # sanity: a rule prompt + suffix still formats without KeyError
+    ("Analyze {code_snippet} at {file_path}" + JSON_ONLY_SUFFIX).format(code_snippet="x", file_path="y")
+
+
+def test_manifest_rules_are_single_source_of_truth():
+    """Regression: strandhogg is manifest-only. It previously leaked into the code
+    deep-scan (missing from the exclusion list) and false-positived on every risky
+    Java file. MANIFEST_RULES is now the single source used by both paths."""
+    from core.engine import MANIFEST_RULES
+    from core.config_loader import RulesSettings
+    valid = set(RulesSettings.model_fields)
+    assert "strandhogg" in MANIFEST_RULES
+    for r in MANIFEST_RULES:
+        assert r in valid, f"MANIFEST_RULES has unknown rule: {r}"
+
+
+def test_dedicated_pass_rules_excluded_from_code_scan():
+    """Regression: rules with their own pass must NOT run in the code deep-scan.
+    hardcoded_secrets_xml (strings.xml-only) leaked onto .java files and false-positived."""
+    from core.engine import MANIFEST_RULES, DEDICATED_PASS_RULES
+    from core.config_loader import RulesSettings
+    valid = set(RulesSettings.model_fields)
+    assert "hardcoded_secrets_xml" in DEDICATED_PASS_RULES
+    assert set(MANIFEST_RULES) <= DEDICATED_PASS_RULES
+    for r in DEDICATED_PASS_RULES:
+        assert r in valid, f"DEDICATED_PASS_RULES has unknown rule: {r}"
+
+
+def test_pattern_matched_files_rescues_first_party_only(tmp_path):
+    """v2 recall fix: files matching a rule detection_pattern must bypass the LLM
+    risk-triage (which dropped ZipSlipActivity pre-gating), but only FIRST-PARTY ones
+    so the added deep-scan cost stays bounded (library files still go through triage)."""
+    import os
+    e = _engine()
+    pkg = tmp_path / "sources" / "com" / "dlh" / "vulnerapp"
+    lib = tmp_path / "sources" / "kotlinx" / "coroutines"
+    pkg.mkdir(parents=True)
+    lib.mkdir(parents=True)
+    app_hit = pkg / "ZipSlipActivity.java"
+    app_hit.write_text("ZipEntry e = zis.getNextEntry(); new File(dir, e.getName());")
+    app_miss = pkg / "Boring.java"
+    app_miss.write_text("int x = 1;")
+    lib_hit = lib / "FastServiceLoader.java"
+    lib_hit.write_text("ZipEntry e; e.getName();")
+    files = [str(app_hit), str(app_miss), str(lib_hit)]
+    patterns = [r"ZipEntry.*(?:\.|->)getName"]
+    out = e._pattern_matched_files(files, patterns, "com.dlh.vulnerapp")
+    assert str(app_hit) in out       # first-party pattern hit -> rescued from triage
+    assert str(app_miss) not in out  # no pattern match -> not added
+    assert str(lib_hit) not in out   # library file -> left to the normal triage
+
+
+def test_file_to_class_dotted():
+    """[B] map a decompiled file path -> dotted class for manifest component lookup."""
+    e = _engine()
+    assert (e._file_to_class_dotted(
+        "/o/App.apk_decompiled/sources/com/dlh/vulnerapp/IntentRedirectionActivity.java")
+        == "com.dlh.vulnerapp.IntentRedirectionActivity")
+    assert e._file_to_class_dotted("/o/dec/smali/com/a/b/C.smali") == "com.a.b.C"
+    assert e._file_to_class_dotted("/o/dec/smali_classes3/com/a/D.smali") == "com.a.D"
+    assert e._file_to_class_dotted("/o/nowhere/Foo.java") is None
+
+
+def test_manifest_get_component_details_childless(tmp_path):
+    """Regression: an <activity/> with NO child nodes is a *falsy* ElementTree Element, so
+    get_component_details used to wrongly return {} for it (e.g. IntentRedirectionActivity,
+    which has no intent-filter). It must be found via `is not None`."""
+    from core.manifest_parser import ManifestParser
+    m = tmp_path / "AndroidManifest.xml"
+    m.write_text(
+        '<?xml version="1.0"?>\n'
+        '<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.x">\n'
+        '  <application>\n'
+        '    <activity android:name="com.x.NoFilterActivity" android:exported="true"/>\n'
+        '    <activity android:name="com.x.WithFilter" android:exported="true">\n'
+        '      <intent-filter><action android:name="a"/></intent-filter>\n'
+        '    </activity>\n'
+        '  </application>\n'
+        '</manifest>\n'
+    )
+    p = ManifestParser(str(m))
+    assert p.get_component_details("com.x.NoFilterActivity").get("exported") == "true"
+    assert p.get_component_details("com.x.WithFilter").get("exported") == "true"
+    assert p.get_component_details("com.x.DoesNotExist") == {}
+
+
+# ---- PoC extension detection: shebang/first-line wins over content sniffing ---
+def test_poc_extension_bash_with_embedded_python_heredoc():
+    """Regression: a real generated PoC was `#!/bin/bash` that embeds a
+    `python3 - << 'EOF' ... EOF` heredoc (to do background logcat monitoring, which
+    Bash can't easily do alone). The old whole-content scan matched "import "/"def "
+    INSIDE the heredoc and saved this valid, directly-executable Bash script as
+    ".py". The shebang must win: it's what the OS actually uses to run the file."""
+    e = _engine()
+    bash_with_heredoc = (
+        "#!/bin/bash\n"
+        "echo starting\n"
+        "python3 - << 'PYEOF'\n"
+        "import subprocess\n"
+        "import threading\n"
+        "def monitor_logcat():\n"
+        "    pass\n"
+        "PYEOF\n"
+    )
+    assert e._detect_poc_extension(bash_with_heredoc) == ".sh"
+
+
+def test_poc_extension_bash_with_embedded_frida_js():
+    """Same principle, different embedded language: shebang still wins."""
+    e = _engine()
+    bash_with_js = "#!/bin/bash\necho hi\n" + "Java.perform(function() { console.log(1); });"
+    assert e._detect_poc_extension(bash_with_js) == ".sh"
+
+
+def test_poc_extension_pure_python():
+    e = _engine()
+    assert e._detect_poc_extension("#!/usr/bin/env python3\nimport os\ndef f(): pass") == ".py"
+
+
+def test_poc_extension_pure_frida_js():
+    e = _engine()
+    assert e._detect_poc_extension("Java.perform(function(){ console.log(1); });") == ".js"
+
+
+def test_poc_extension_pure_html():
+    e = _engine()
+    assert e._detect_poc_extension("<!DOCTYPE html>\n<html><body></body></html>") == ".html"
+
+
+def test_poc_extension_falls_back_to_content_sniffing_without_shebang():
+    """No shebang / first-line signal at all -> content-sniffing fallback still works."""
+    e = _engine()
+    assert e._detect_poc_extension("some notes\nadb shell am start -n a/b\n") == ".sh"
+    assert e._detect_poc_extension("some notes\nimport os\nrest of script\n") == ".py"
+
+
+def test_poc_extension_unknown_content_is_txt():
+    e = _engine()
+    assert e._detect_poc_extension("just some random output with no signals") == ".txt"
+
+
+# ---- exploit-generation provider routing (llm.exploit_provider/exploit_model) --
+def _llm_settings(**overrides):
+    base = dict(
+        provider="ollama", model="deepseek-coder-v2:latest", ollama_url="http://localhost:11434",
+        gemini_model="gemini-2.0-flash", gemini_api_key="g",
+        groq_model="llama-3.1-8b-instant", groq_api_key="g",
+        openai_model="gpt-4-turbo", openai_api_key="o",
+        anthropic_model="claude-opus-4-6", anthropic_api_key="a",
+        openrouter_model="moonshotai/kimi-k3", openrouter_api_key="or",
+        router9_model="gc/gemini-2.5-pro", router9_api_key="r9", router9_base_url="http://localhost:20128/v1/chat/completions",
+        max_tokens=4096, exploit_provider=None, exploit_model=None,
+    )
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+def _engine_with_settings(generate_exploit, use_cache=False, **llm_overrides):
+    e = _engine()
+    e.settings = types.SimpleNamespace(
+        llm=_llm_settings(**llm_overrides),
+        analysis=types.SimpleNamespace(use_cache=use_cache, generate_exploit=generate_exploit),
+    )
+    return e
+
+
+def test_build_llm_client_model_override():
+    e = _engine()
+    e.settings = types.SimpleNamespace(llm=_llm_settings(), analysis=types.SimpleNamespace(use_cache=False))
+    client = e._build_llm_client("anthropic", model_override="custom-model")
+    assert client.model == "custom-model"  # override wins over anthropic_model default
+    default_client = e._build_llm_client("anthropic")
+    assert default_client.model == "claude-opus-4-6"  # no override -> that provider's own default
+
+
+def test_exploit_client_defaults_to_main_when_unset():
+    """No exploit_provider/exploit_model set -> exploit generation reuses the main client
+    (no second object built at all)."""
+    e = _engine_with_settings(generate_exploit=True)
+    e._setup_llm_client()
+    assert e.exploit_llm_client is e.llm_client
+
+
+def test_exploit_client_skipped_when_generate_exploit_is_off():
+    """A typo'd/unused exploit_provider must NEVER affect a normal scan: the separate
+    client is only built when exploit generation is actually requested."""
+    e = _engine_with_settings(generate_exploit=False, exploit_provider="anthropic")
+    e._setup_llm_client()
+    assert e.exploit_llm_client is e.llm_client
+
+
+def test_exploit_client_routes_to_separate_provider():
+    e = _engine_with_settings(generate_exploit=True, exploit_provider="anthropic")
+    e._setup_llm_client()
+    assert e.exploit_llm_client is not e.llm_client
+    assert e.exploit_llm_client.model == "claude-opus-4-6"
+    assert e.llm_client.model == "deepseek-coder-v2:latest"  # main (ollama) client untouched
+
+
+def test_exploit_client_model_override_without_changing_provider():
+    """exploit_model alone (same provider as main) must still build a separate client."""
+    e = _engine_with_settings(generate_exploit=True, provider="anthropic", exploit_model="claude-sonnet-4-5")
+    e._setup_llm_client()
+    assert e.exploit_llm_client is not e.llm_client
+    assert e.exploit_llm_client.model == "claude-sonnet-4-5"
+    assert e.llm_client.model == "claude-opus-4-6"
+
+
+def test_exploit_client_falls_back_on_bad_provider():
+    """A misconfigured exploit_provider must not crash the scan -> falls back to main."""
+    e = _engine_with_settings(generate_exploit=True, exploit_provider="not_a_real_provider")
+    e._setup_llm_client()  # must not raise
+    assert e.exploit_llm_client is e.llm_client
+
+
+# ---- attack surface map: structured inventory, not narrative text -------------
+class _StubLLM:
+    def __init__(self, response):
+        self.response = response
+
+    def analyze_code(self, code, ctx):
+        return self.response
+
+
+def test_attack_surface_map_returns_parsed_dict_on_success(tmp_path):
+    """v1.3.0: was a raw narrative string; now a small structured inventory dict."""
+    e = _engine()
+    e.llm_client = _StubLLM(
+        '{"exported_activities": ["WebViewActivity"], "deep_links": '
+        '[{"scheme": "dlh", "host": "webview", "handler": "WebViewActivity"}], '
+        '"network": ["webview"], "file_io": false, "ipc": true, '
+        '"deserialization": false, "reflection": false, "manifest_flags": {"debuggable": true}}'
+    )
+    manifest = tmp_path / "AndroidManifest.xml"
+    manifest.write_text("<manifest/>")
+    result = e.generate_attack_surface_map(str(manifest), {})
+    assert isinstance(result, dict)
+    assert result["exported_activities"] == ["WebViewActivity"]
+    assert result["deep_links"][0]["handler"] == "WebViewActivity"
+    assert result["ipc"] is True
+    assert "error" not in result
+
+
+def test_attack_surface_map_reports_error_on_empty_response(tmp_path):
+    e = _engine()
+    e.llm_client = _StubLLM("")
+    manifest = tmp_path / "AndroidManifest.xml"
+    manifest.write_text("<manifest/>")
+    result = e.generate_attack_surface_map(str(manifest), {})
+    assert "error" in result  # transparent failure, not a silent empty/null map
+
+
+def test_attack_surface_map_reports_error_on_unparseable_response(tmp_path):
+    e = _engine()
+    e.llm_client = _StubLLM("Sure, here is the attack surface: WebViewActivity is exported...")
+    manifest = tmp_path / "AndroidManifest.xml"
+    manifest.write_text("<manifest/>")
+    result = e.generate_attack_surface_map(str(manifest), {})
+    assert "error" in result
+    assert "is_vulnerable" not in result  # must NOT leak the vuln-verdict fallback shape
+
+
+# ---- 9Router client: SSE stream parsing -----------------------------------------
+class _FakeSSEResponse:
+    """Mimics requests.Response.iter_lines() for a 9Router-style SSE stream."""
+    def __init__(self, lines):
+        self._lines = lines
+
+    def iter_lines(self, decode_unicode=True):
+        return iter(self._lines)
+
+
+def _router9():
+    return Router9Client(model="gc/gemini-2.5-pro", api_key="k", base_url="http://x/v1/chat/completions")
+
+
+def test_router9_parses_real_world_sse_stream():
+    """Regression fixture: the exact SSE shape observed from a real 9Router instance
+    (chat.completion.chunk objects, role-only first delta, content delta, then a
+    finish_reason chunk with usage) — no `stream:true` was even requested."""
+    r9 = _router9()
+    lines = [
+        '',
+        'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-2.5-pro","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
+        '',
+        'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-2.5-pro","choices":[{"index":0,"delta":{"content":"Hello "},"finish_reason":null}]}',
+        'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-2.5-pro","choices":[{"index":0,"delta":{"content":"9Router!"},"finish_reason":null}]}',
+        'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-2.5-pro","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}',
+        'data: [DONE]',
+    ]
+    assert r9._parse_sse_stream(_FakeSSEResponse(lines)) == "Hello 9Router!"
+
+
+def test_router9_sse_stream_stops_at_done_and_skips_malformed():
+    r9 = _router9()
+    lines = [
+        'data: {"choices":[{"delta":{"content":"A"}}]}',
+        'data: not-json-garbage',
+        'data: {"choices":[{"delta":{"content":"B"}}]}',
+        'data: [DONE]',
+        'data: {"choices":[{"delta":{"content":"C-should-not-appear"}}]}',
+    ]
+    assert r9._parse_sse_stream(_FakeSSEResponse(lines)) == "AB"
+
+
+def test_router9_sse_stream_empty_on_no_data_lines():
+    r9 = _router9()
+    assert r9._parse_sse_stream(_FakeSSEResponse(["", "not an sse line"])) == ""
+
+
+def test_router9_construct_prompt_survives_braces_in_code():
+    """Java/Kotlin code is full of '{' '}' — .format() must not choke on the VALUE,
+    only on stray braces in the TEMPLATE (already covered by test_json_only_suffix_is_format_safe)."""
+    r9 = _router9()
+    prompt = r9._construct_prompt(
+        "if (a) { b(); }",
+        {"system_prompt": "SYS", "vuln_prompt": "Analyze {code_snippet} at {file_path}", "file_path": "F.java"},
+    )
+    assert "if (a) { b(); }" in prompt and "F.java" in prompt and prompt.startswith("SYS")
+
+
 def test_path_to_class_java_and_smali(tmp_path):
     import os
     cg = CallGraphBuilder(str(tmp_path))


### PR DESCRIPTION
This release makes the detection **verifiable** and the rule prompts **consistent**. It adds a semantic Golden Test (Layer 2) that runs real scans against the `VulnerAppDLH` testbed and asserts a recall contract, then uses that safety net to standardize all 26 vulnerability-rule prompts, redesign a few misleading detection patterns, and close two recall gaps - all proven not to regress detection (recall held **16/16** across every change).