### PR TITLE
fixed router9 client silently

### DIFF
--- a/modules/llm_client/router9.py
+++ b/modules/llm_client/router9.py
@@ -15,9 +15,16 @@ class Router9Client(BaseLLMClient):
     Unlike those other OpenAI-compatible clients, 9Router's /v1/chat/completions endpoint
     was observed to return a Server-Sent Events (SSE) stream even for a plain request with
     no `"stream"` key set — responses arrive as `data: {...}` chunks with `chat.completion.chunk`
-    objects and per-token `delta.content` fragments, not a single JSON body. This client
-    detects that via the `Content-Type` response header and parses accordingly, falling
-    back to a normal single-JSON response if the router ever returns one instead.
+    objects and per-token `delta.content` fragments, not a single JSON body.
+
+    However, the `Content-Type: text/event-stream` header is NOT a reliable signal of the
+    actual body shape: 9Router has been observed sending `text/event-stream` while the body
+    is a single complete (non-chunked) `chat.completion` JSON object glued directly to a
+    trailing `data: [DONE]` with no separating newline, e.g.
+    `{"id":...,"choices":[{"message":{"content":"..."}}]}data: [DONE]\n\n`. Since that blob
+    never starts with `data:`, a naive SSE line-parser silently drops it and returns empty
+    content on every single call. This client therefore ignores the header and instead
+    sniffs the response body itself to decide whether it's SSE or a plain JSON object.
     """
 
     def __init__(self, model: str, api_key: str, base_url: str, max_tokens: int = 4096):
@@ -65,16 +72,8 @@ class Router9Client(BaseLLMClient):
 
                     response.raise_for_status()
 
-                    content_type = response.headers.get("Content-Type", "")
-                    if "text/event-stream" in content_type:
-                        content = self._parse_sse_stream(response)
-                    else:
-                        result = response.json()
-                        if "error" in result:
-                            log.error(f"9Router API returned error: {result['error']}")
-                            raise requests.exceptions.RequestException(f"9Router API Error: {result['error']}")
-                        choices = result.get("choices") or []
-                        content = choices[0]["message"]["content"] if choices else ""
+                    body = response.text
+                    content = self._extract_content(body)
                 if content:
                     log.success("Received analysis from 9Router.")
                 return content
@@ -86,11 +85,21 @@ class Router9Client(BaseLLMClient):
         log.error(f"9Router API failed after {max_retries} attempts.")
         return ""
 
-    def _parse_sse_stream(self, response) -> str:
+    def _extract_content(self, body: str) -> str:
+        """Sniffs the response body to tell an SSE stream apart from a plain JSON object
+        (the `Content-Type` header can't be trusted to say which one it actually is —
+        see class docstring)."""
+        stripped = body.lstrip()
+        if stripped.startswith("data:"):
+            return self._parse_sse_stream(stripped)
+        return self._parse_plain_json(stripped)
+
+    def _parse_sse_stream(self, body: str) -> str:
         """Accumulates `delta.content` fragments from an OpenAI-style SSE stream
         (`data: {...}` lines, terminated by `data: [DONE]`)."""
         chunks = []
-        for raw_line in response.iter_lines(decode_unicode=True):
+        for raw_line in body.splitlines():
+            raw_line = raw_line.strip()
             if not raw_line or not raw_line.startswith("data:"):
                 continue
             payload = raw_line[len("data:"):].strip()
@@ -111,6 +120,21 @@ class Router9Client(BaseLLMClient):
             if piece:
                 chunks.append(piece)
         return "".join(chunks)
+
+    def _parse_plain_json(self, body: str) -> str:
+        """Parses a single `chat.completion` JSON object, tolerating trailing garbage
+        (9Router has been observed appending a stray `data: [DONE]` directly after the
+        JSON with no separator)."""
+        try:
+            result, _ = json.JSONDecoder().raw_decode(body)
+        except json.JSONDecodeError as e:
+            log.error(f"9Router returned unparseable response: {e}")
+            return ""
+        if "error" in result:
+            log.error(f"9Router API returned error: {result['error']}")
+            raise requests.exceptions.RequestException(f"9Router API Error: {result['error']}")
+        choices = result.get("choices") or []
+        return choices[0]["message"]["content"] if choices else ""
 
     def _construct_prompt(self, code_snippet: str, context: Dict[str, Any]) -> str:
         system_prompt = context.get("system_prompt", "")

--- a/tests/test_pure_functions.py
+++ b/tests/test_pure_functions.py
@@ -444,16 +444,7 @@ def test_attack_surface_map_reports_error_on_unparseable_response(tmp_path):
     assert "is_vulnerable" not in result  # must NOT leak the vuln-verdict fallback shape
 
 
-# ---- 9Router client: SSE stream parsing -----------------------------------------
-class _FakeSSEResponse:
-    """Mimics requests.Response.iter_lines() for a 9Router-style SSE stream."""
-    def __init__(self, lines):
-        self._lines = lines
-
-    def iter_lines(self, decode_unicode=True):
-        return iter(self._lines)
-
-
+# ---- 9Router client: response body parsing ---------------------------------------
 def _router9():
     return Router9Client(model="gc/gemini-2.5-pro", api_key="k", base_url="http://x/v1/chat/completions")
 
@@ -463,7 +454,7 @@ def test_router9_parses_real_world_sse_stream():
     (chat.completion.chunk objects, role-only first delta, content delta, then a
     finish_reason chunk with usage) — no `stream:true` was even requested."""
     r9 = _router9()
-    lines = [
+    body = "\n".join([
         '',
         'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-2.5-pro","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}',
         '',
@@ -471,25 +462,48 @@ def test_router9_parses_real_world_sse_stream():
         'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-2.5-pro","choices":[{"index":0,"delta":{"content":"9Router!"},"finish_reason":null}]}',
         'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gemini-2.5-pro","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}',
         'data: [DONE]',
-    ]
-    assert r9._parse_sse_stream(_FakeSSEResponse(lines)) == "Hello 9Router!"
+    ])
+    assert r9._extract_content(body) == "Hello 9Router!"
 
 
 def test_router9_sse_stream_stops_at_done_and_skips_malformed():
     r9 = _router9()
-    lines = [
+    body = "\n".join([
         'data: {"choices":[{"delta":{"content":"A"}}]}',
         'data: not-json-garbage',
         'data: {"choices":[{"delta":{"content":"B"}}]}',
         'data: [DONE]',
         'data: {"choices":[{"delta":{"content":"C-should-not-appear"}}]}',
-    ]
-    assert r9._parse_sse_stream(_FakeSSEResponse(lines)) == "AB"
+    ])
+    assert r9._extract_content(body) == "AB"
 
 
 def test_router9_sse_stream_empty_on_no_data_lines():
     r9 = _router9()
-    assert r9._parse_sse_stream(_FakeSSEResponse(["", "not an sse line"])) == ""
+    assert r9._extract_content("\n".join(["", "not an sse line"])) == ""
+
+
+def test_router9_extracts_plain_json_mislabeled_as_event_stream():
+    """Regression: 9Router has been observed sending `Content-Type: text/event-stream`
+    while the actual body is a single complete `chat.completion` JSON object glued
+    directly to a trailing `data: [DONE]` with NO separating newline. Since that blob
+    never starts with `data:`, the old line-based SSE parser silently dropped it and
+    every single 9Router call returned empty content — this is the exact shape that
+    triggered '9Router API returned empty response' during real scans."""
+    r9 = _router9()
+    body = (
+        '{"id":"chatcmpl-1","object":"chat.completion","created":1,"model":"cbcn-glm-5.2",'
+        '"choices":[{"index":0,"message":{"role":"assistant","content":"Hello!"},'
+        '"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}'
+        'data: [DONE]\n\n'
+    )
+    assert r9._extract_content(body) == "Hello!"
+
+
+def test_router9_extracts_plain_json_without_trailing_garbage():
+    r9 = _router9()
+    body = '{"choices":[{"message":{"content":"plain response"}}]}'
+    assert r9._extract_content(body) == "plain response"
 
 
 def test_router9_construct_prompt_survives_braces_in_code():


### PR DESCRIPTION
## Problem

Every LLM call routed through the `router9` provider returned empty content,
even though the HTTP request succeeded (200 OK). This surfaced as:

- `Attack surface map generation failed (empty LLM response)`
- `LLM analysis failed for rule 'X'; marking as Error (not clean)` for every
  deep-scan target
- `Identified 0 risky files` even on an APK with known-vulnerable code

Anthropic-backed scans on the same APK worked fine, which pointed at the
router9 client specifically rather than the analysis pipeline.